### PR TITLE
feat(observability): OBS-01 structured JSON logging with request context

### DIFF
--- a/src/sovyx/cognitive/gate.py
+++ b/src/sovyx/cognitive/gate.py
@@ -13,7 +13,7 @@ import itertools
 from typing import TYPE_CHECKING
 
 from sovyx.engine.errors import CognitiveError
-from sovyx.observability.logging import get_logger
+from sovyx.observability.logging import bind_request_context, clear_request_context, get_logger
 
 if TYPE_CHECKING:
     from sovyx.cognitive.act import ActionResult
@@ -117,7 +117,12 @@ class CogLoopGate:
         logger.info("cogloop_gate_stopped")
 
     async def _worker(self) -> None:
-        """Single worker draining the queue."""
+        """Single worker draining the queue.
+
+        Binds request-scoped logging context (mind_id, conversation_id,
+        request_id) before processing each request, so every log emitted
+        during the cognitive loop carries full tracing context.
+        """
         while self._running:
             try:
                 priority, _, request, future = await asyncio.wait_for(
@@ -126,6 +131,12 @@ class CogLoopGate:
             except (TimeoutError, asyncio.CancelledError):
                 continue
 
+            # Bind structured context for the lifetime of this request
+            clear_request_context()
+            bind_request_context(
+                mind_id=str(request.mind_id),
+                conversation_id=str(request.conversation_id),
+            )
             try:
                 result = await self._loop.process_request(request)
                 if not future.done():
@@ -133,3 +144,5 @@ class CogLoopGate:
             except Exception as e:
                 if not future.done():
                     future.set_exception(e)
+            finally:
+                clear_request_context()

--- a/src/sovyx/observability/__init__.py
+++ b/src/sovyx/observability/__init__.py
@@ -1,1 +1,19 @@
-"""Sovyx Observability — Structured logging, correlation IDs, metrics."""
+"""Sovyx Observability — Structured logging, request context, metrics."""
+
+from sovyx.observability.logging import (
+    bind_request_context,
+    bound_request_context,
+    clear_request_context,
+    get_logger,
+    get_request_context,
+    setup_logging,
+)
+
+__all__ = [
+    "bind_request_context",
+    "bound_request_context",
+    "clear_request_context",
+    "get_logger",
+    "get_request_context",
+    "setup_logging",
+]

--- a/src/sovyx/observability/logging.py
+++ b/src/sovyx/observability/logging.py
@@ -1,36 +1,156 @@
 """Sovyx structured logging.
 
-Configures structlog with JSON/console output, correlation IDs,
-and secret masking for sensitive fields.
+Configures structlog with JSON/console output, request-scoped context
+(mind_id, conversation_id, request_id), and secret masking for sensitive fields.
+
+Context Binding
+---------------
+Use :func:`bind_request_context` at the entry point of each request
+(e.g. CogLoopGate worker) to inject ``mind_id``, ``conversation_id``,
+and ``request_id`` into **every** log emitted within that async context.
+Use :func:`clear_request_context` (or the :func:`bound_request_context`
+context manager) to reset when the request is done.
+
+The context is carried via ``structlog.contextvars``, which is both
+thread-safe and asyncio-safe.
 """
 
 from __future__ import annotations
 
 import logging
 import sys
-from contextvars import ContextVar
+import uuid
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 import structlog
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Generator, MutableMapping
 
     from sovyx.engine.config import LoggingConfig
 
-# ── Correlation ID management ───────────────────────────────────────────────
+# ── Request Context (via structlog.contextvars) ─────────────────────────────
 
-_correlation_id: ContextVar[str] = ContextVar("correlation_id", default="")
+# Keys managed by the request context.  Other modules may bind extra
+# keys — these are the ones we guarantee and clear on reset.
+_REQUEST_CONTEXT_KEYS: frozenset[str] = frozenset(
+    {"mind_id", "conversation_id", "request_id", "correlation_id"},
+)
+
+
+def bind_request_context(
+    *,
+    mind_id: str = "",
+    conversation_id: str = "",
+    request_id: str | None = None,
+    correlation_id: str = "",
+    **extra: Any,  # noqa: ANN401
+) -> None:
+    """Bind request-scoped fields into the structlog context.
+
+    All subsequent log calls in the **same async context** will include
+    these fields automatically (via ``merge_contextvars`` processor).
+
+    Args:
+        mind_id: The mind being served (e.g. ``"default"``).
+        conversation_id: Active conversation identifier.
+        request_id: Unique ID for this request.  Auto-generated
+            (UUID4 short form) when ``None``.
+        correlation_id: Optional correlation / trace ID.  Kept for
+            backward compatibility with the event bus.
+        **extra: Any additional key-value pairs to include.
+    """
+    if request_id is None:
+        request_id = uuid.uuid4().hex[:12]
+
+    bindings: dict[str, Any] = {
+        "request_id": request_id,
+    }
+    if mind_id:
+        bindings["mind_id"] = mind_id
+    if conversation_id:
+        bindings["conversation_id"] = conversation_id
+    if correlation_id:
+        bindings["correlation_id"] = correlation_id
+    if extra:
+        bindings.update(extra)
+
+    structlog.contextvars.bind_contextvars(**bindings)
+
+
+def clear_request_context() -> None:
+    """Remove all request-scoped context from the current async context.
+
+    Clears **only** the keys managed by :func:`bind_request_context`
+    plus any extra keys previously bound via ``structlog.contextvars``.
+    """
+    structlog.contextvars.clear_contextvars()
+
+
+def get_request_context() -> dict[str, Any]:
+    """Return a copy of the current structlog context-var bindings."""
+    return dict(structlog.contextvars.get_contextvars())
+
+
+@contextmanager
+def bound_request_context(
+    *,
+    mind_id: str = "",
+    conversation_id: str = "",
+    request_id: str | None = None,
+    correlation_id: str = "",
+    **extra: Any,  # noqa: ANN401
+) -> Generator[None, None, None]:
+    """Context manager that binds request context on entry and clears on exit.
+
+    Usage::
+
+        with bound_request_context(mind_id="default", conversation_id="abc"):
+            logger.info("inside request")  # includes mind_id, conversation_id
+        # context is cleared here
+
+    This works correctly in both sync and async code because
+    ``structlog.contextvars`` is backed by Python ``contextvars``.
+    """
+    tokens = structlog.contextvars.bind_contextvars(
+        mind_id=mind_id or "",
+        conversation_id=conversation_id or "",
+        request_id=request_id if request_id is not None else uuid.uuid4().hex[:12],
+        **({"correlation_id": correlation_id} if correlation_id else {}),
+        **extra,
+    )
+    try:
+        yield
+    finally:
+        structlog.contextvars.reset_contextvars(**tokens)
+
+
+# ── Backward Compatibility ──────────────────────────────────────────────────
+# Events module uses set_correlation_id / get_correlation_id.
+# Keep working — now delegates to structlog.contextvars.
 
 
 def set_correlation_id(cid: str) -> None:
-    """Set correlation ID for the current async context."""
-    _correlation_id.set(cid)
+    """Set correlation ID for the current async context.
+
+    .. deprecated:: 0.2
+        Use :func:`bind_request_context` instead.
+    """
+    if cid:
+        structlog.contextvars.bind_contextvars(correlation_id=cid)
+    else:
+        structlog.contextvars.unbind_contextvars("correlation_id")
 
 
 def get_correlation_id() -> str:
-    """Get correlation ID for the current async context."""
-    return _correlation_id.get()
+    """Get correlation ID for the current async context.
+
+    .. deprecated:: 0.2
+        Use :func:`get_request_context` instead.
+    """
+    ctx = structlog.contextvars.get_contextvars()
+    return str(ctx.get("correlation_id", ""))
 
 
 # ── Secret Masking ──────────────────────────────────────────────────────────
@@ -72,21 +192,6 @@ class SecretMasker:
         return event_dict
 
 
-# ── Correlation ID Processor ────────────────────────────────────────────────
-
-
-def _add_correlation_id(
-    logger: Any,  # noqa: ANN401
-    method_name: str,
-    event_dict: MutableMapping[str, Any],
-) -> MutableMapping[str, Any]:
-    """Inject correlation_id from contextvars into every log event."""
-    cid = _correlation_id.get()
-    if cid:
-        event_dict["correlation_id"] = cid
-    return event_dict
-
-
 # ── Setup ───────────────────────────────────────────────────────────────────
 
 _setup_done = False
@@ -102,6 +207,15 @@ def setup_logging(config: LoggingConfig) -> None:
         - Configures structlog globally with shared processors.
         - Sets stdlib logging level.
         - JSON output for production, colored console for development.
+
+    Processor chain (in order):
+        1. ``merge_contextvars`` — inject request-scoped context
+        2. ``add_log_level`` — add ``level`` field
+        3. ``add_logger_name`` — add ``logger`` field
+        4. ``TimeStamper`` — ISO-8601 timestamp
+        5. ``StackInfoRenderer`` — optional stack trace
+        6. ``SecretMasker`` — redact sensitive values
+        7. Renderer (JSON or console)
     """
     global _setup_done  # noqa: PLW0603
 
@@ -111,7 +225,6 @@ def setup_logging(config: LoggingConfig) -> None:
         structlog.stdlib.add_logger_name,
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
-        _add_correlation_id,
         SecretMasker(),
     ]
 
@@ -156,7 +269,9 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
         name: Module name (typically __name__).
 
     Returns:
-        Configured structlog BoundLogger.
+        Configured structlog BoundLogger.  Any context bound via
+        :func:`bind_request_context` is automatically included in
+        every log call from this logger.
     """
     result: structlog.stdlib.BoundLogger = structlog.get_logger(name)
     return result

--- a/src/sovyx/observability/logging.py
+++ b/src/sovyx/observability/logging.py
@@ -32,12 +32,6 @@ if TYPE_CHECKING:
 
 # ── Request Context (via structlog.contextvars) ─────────────────────────────
 
-# Keys managed by the request context.  Other modules may bind extra
-# keys — these are the ones we guarantee and clear on reset.
-_REQUEST_CONTEXT_KEYS: frozenset[str] = frozenset(
-    {"mind_id", "conversation_id", "request_id", "correlation_id"},
-)
-
 
 def bind_request_context(
     *,

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -141,9 +141,7 @@ class TestBindRequestContext:
         assert len(ctx["request_id"]) == 12  # hex[:12]
 
     def test_bind_with_explicit_request_id(self) -> None:
-        bind_request_context(
-            mind_id="m", conversation_id="c", request_id="my-req-id"
-        )
+        bind_request_context(mind_id="m", conversation_id="c", request_id="my-req-id")
         ctx = get_request_context()
         assert ctx["request_id"] == "my-req-id"
 
@@ -172,9 +170,7 @@ class TestBindRequestContext:
         assert "conversation_id" not in ctx
 
     def test_bind_extra_kwargs(self) -> None:
-        bind_request_context(
-            mind_id="m", conversation_id="c", person_name="Guipe"
-        )
+        bind_request_context(mind_id="m", conversation_id="c", person_name="Guipe")
         ctx = get_request_context()
         assert ctx["person_name"] == "Guipe"
 
@@ -214,9 +210,7 @@ class TestBoundRequestContext:
         assert ctx["mind_id"] == "outer"
 
     def test_fixed_request_id(self) -> None:
-        with bound_request_context(
-            mind_id="m", conversation_id="c", request_id="fixed-123"
-        ):
+        with bound_request_context(mind_id="m", conversation_id="c", request_id="fixed-123"):
             assert get_request_context()["request_id"] == "fixed-123"
 
     def test_auto_request_id(self) -> None:
@@ -394,9 +388,7 @@ class TestJSONOutput:
 
     def test_bound_context_manager_in_json(self) -> None:
         logger = get_logger("test.json")
-        with bound_request_context(
-            mind_id="ctx-m", conversation_id="ctx-c", request_id="ctx-r"
-        ):
+        with bound_request_context(mind_id="ctx-m", conversation_id="ctx-c", request_id="ctx-r"):
             parsed = self._capture_log(logger, "info", "in_ctx")
         assert parsed["mind_id"] == "ctx-m"
         assert parsed["request_id"] == "ctx-r"

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -1,18 +1,46 @@
-"""Tests for sovyx.observability.logging — structured logging."""
+"""Tests for sovyx.observability.logging — structured logging with request context."""
 
 from __future__ import annotations
 
-import asyncio
+import io
+import json
 import logging
+from typing import Any
+
+import pytest
+import structlog
 
 from sovyx.engine.config import LoggingConfig
 from sovyx.observability.logging import (
     SecretMasker,
+    bind_request_context,
+    bound_request_context,
+    clear_request_context,
     get_correlation_id,
     get_logger,
+    get_request_context,
     set_correlation_id,
     setup_logging,
 )
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clean_context() -> None:
+    """Ensure every test starts and ends with a clean structlog context."""
+    clear_request_context()
+    yield  # type: ignore[misc]
+    clear_request_context()
+
+
+@pytest.fixture()
+def _json_logging() -> None:
+    """Set up JSON logging for tests that need real output."""
+    setup_logging(LoggingConfig(level="DEBUG", format="json"))
+
+
+# ── SecretMasker ────────────────────────────────────────────────────────────
 
 
 class TestSecretMasker:
@@ -20,50 +48,50 @@ class TestSecretMasker:
 
     def test_masks_token_field(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "token": "sk-1234567890abcdef"}
+        event: dict[str, Any] = {"event": "test", "token": "sk-1234567890abcdef"}
         result = masker(None, "info", event)
         assert result["token"] == "sk-...def"
 
     def test_masks_api_key_field(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "api_key": "key-abcdefghijklmnop"}
+        event: dict[str, Any] = {"event": "test", "api_key": "key-abcdefghijklmnop"}
         result = masker(None, "info", event)
         assert result["api_key"] == "key...nop"
 
     def test_masks_password_field(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "password": "mysecretpassword"}
+        event: dict[str, Any] = {"event": "test", "password": "mysecretpassword"}
         result = masker(None, "info", event)
         assert result["password"] == "mys...ord"
 
     def test_masks_secret_field(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "client_secret": "abcdefghij"}
+        event: dict[str, Any] = {"event": "test", "client_secret": "abcdefghij"}
         result = masker(None, "info", event)
         assert result["client_secret"] == "abc...hij"
 
     def test_short_value_fully_masked(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "token": "short"}
+        event: dict[str, Any] = {"event": "test", "token": "short"}
         result = masker(None, "info", event)
         assert result["token"] == "***"
 
     def test_does_not_mask_normal_fields(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "user_name": "guipe", "count": 42}
+        event: dict[str, Any] = {"event": "test", "user_name": "guipe", "count": 42}
         result = masker(None, "info", event)
         assert result["user_name"] == "guipe"
         assert result["count"] == 42
 
     def test_does_not_mask_non_string_sensitive(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "token": 12345}
+        event: dict[str, Any] = {"event": "test", "token": 12345}
         result = masker(None, "info", event)
         assert result["token"] == 12345  # non-string, not masked
 
     def test_case_insensitive(self) -> None:
         masker = SecretMasker()
-        event = {"event": "test", "API_KEY": "abcdefghijklmnop"}
+        event: dict[str, Any] = {"event": "test", "API_KEY": "abcdefghijklmnop"}
         result = masker(None, "info", event)
         assert result["API_KEY"] == "abc...nop"
 
@@ -79,46 +107,170 @@ class TestSecretMasker:
         assert SecretMasker._mask_value("abcdefghij") == "abc...hij"
 
     def test_mask_value_short(self) -> None:
-        assert SecretMasker._mask_value("short") == "***"
+        assert SecretMasker._mask_value("abc") == "***"
 
     def test_mask_value_boundary(self) -> None:
-        # Exactly 8 chars
+        # Exactly 8 chars: "12345678" → "123...678"
         assert SecretMasker._mask_value("12345678") == "123...678"
-        # 7 chars — still short
+
+    def test_mask_value_7_chars(self) -> None:
+        # 7 chars: fully masked
         assert SecretMasker._mask_value("1234567") == "***"
 
+    def test_api_key_env_sensitive(self) -> None:
+        """api_key_env is in the sensitive set."""
+        masker = SecretMasker()
+        event: dict[str, Any] = {"event": "test", "api_key_env": "OPENAI_KEY"}
+        result = masker(None, "info", event)
+        # "OPENAI_KEY" is 10 chars → masked as first3...last3
+        assert result["api_key_env"] == "OPE...KEY"
 
-class TestCorrelationId:
-    """Correlation ID management via contextvars."""
 
-    def test_default_is_empty(self) -> None:
-        # Reset to default
+# ── Request Context ─────────────────────────────────────────────────────────
+
+
+class TestBindRequestContext:
+    """bind_request_context / clear / get."""
+
+    def test_bind_and_get(self) -> None:
+        bind_request_context(mind_id="test-mind", conversation_id="conv-1")
+        ctx = get_request_context()
+        assert ctx["mind_id"] == "test-mind"
+        assert ctx["conversation_id"] == "conv-1"
+        assert "request_id" in ctx  # auto-generated
+        assert len(ctx["request_id"]) == 12  # hex[:12]
+
+    def test_bind_with_explicit_request_id(self) -> None:
+        bind_request_context(
+            mind_id="m", conversation_id="c", request_id="my-req-id"
+        )
+        ctx = get_request_context()
+        assert ctx["request_id"] == "my-req-id"
+
+    def test_bind_with_correlation_id(self) -> None:
+        bind_request_context(
+            mind_id="m",
+            conversation_id="c",
+            correlation_id="trace-xyz",
+        )
+        ctx = get_request_context()
+        assert ctx["correlation_id"] == "trace-xyz"
+
+    def test_bind_without_correlation_id_omits_key(self) -> None:
+        bind_request_context(mind_id="m", conversation_id="c")
+        ctx = get_request_context()
+        assert "correlation_id" not in ctx
+
+    def test_bind_empty_mind_id_omits_key(self) -> None:
+        bind_request_context(mind_id="", conversation_id="c")
+        ctx = get_request_context()
+        assert "mind_id" not in ctx
+
+    def test_bind_empty_conversation_id_omits_key(self) -> None:
+        bind_request_context(mind_id="m", conversation_id="")
+        ctx = get_request_context()
+        assert "conversation_id" not in ctx
+
+    def test_bind_extra_kwargs(self) -> None:
+        bind_request_context(
+            mind_id="m", conversation_id="c", person_name="Guipe"
+        )
+        ctx = get_request_context()
+        assert ctx["person_name"] == "Guipe"
+
+    def test_clear_removes_all(self) -> None:
+        bind_request_context(mind_id="m", conversation_id="c")
+        clear_request_context()
+        assert get_request_context() == {}
+
+    def test_auto_generated_request_id_is_unique(self) -> None:
+        bind_request_context(mind_id="m", conversation_id="c")
+        rid1 = get_request_context()["request_id"]
+        clear_request_context()
+        bind_request_context(mind_id="m", conversation_id="c")
+        rid2 = get_request_context()["request_id"]
+        assert rid1 != rid2
+
+
+class TestBoundRequestContext:
+    """bound_request_context context manager."""
+
+    def test_binds_on_entry_resets_on_exit(self) -> None:
+        with bound_request_context(mind_id="inner", conversation_id="c1"):
+            ctx = get_request_context()
+            assert ctx["mind_id"] == "inner"
+        # After exit — context should be clean (no leaks)
+        after = get_request_context()
+        assert "mind_id" not in after or after.get("mind_id") == ""
+
+    def test_restores_previous_context(self) -> None:
+        bind_request_context(mind_id="outer", conversation_id="outer-c")
+        with bound_request_context(
+            mind_id="inner", conversation_id="inner-c", request_id="r-inner"
+        ):
+            assert get_request_context()["mind_id"] == "inner"
+        # Outer restored
+        ctx = get_request_context()
+        assert ctx["mind_id"] == "outer"
+
+    def test_fixed_request_id(self) -> None:
+        with bound_request_context(
+            mind_id="m", conversation_id="c", request_id="fixed-123"
+        ):
+            assert get_request_context()["request_id"] == "fixed-123"
+
+    def test_auto_request_id(self) -> None:
+        with bound_request_context(mind_id="m", conversation_id="c"):
+            rid = get_request_context()["request_id"]
+            assert len(rid) == 12
+
+    def test_with_correlation_id(self) -> None:
+        with bound_request_context(
+            mind_id="m",
+            conversation_id="c",
+            correlation_id="trace-1",
+        ):
+            assert get_request_context()["correlation_id"] == "trace-1"
+        assert "correlation_id" not in get_request_context()
+
+    def test_cleanup_on_exception(self) -> None:
+        """Context is properly cleaned up even if body raises."""
+        with (
+            pytest.raises(ValueError, match="boom"),
+            bound_request_context(mind_id="m", conversation_id="c"),
+        ):
+            raise ValueError("boom")
+        # Must be clean
+        assert "mind_id" not in get_request_context()
+
+
+# ── Backward Compatibility ──────────────────────────────────────────────────
+
+
+class TestCorrelationIdCompat:
+    """set_correlation_id / get_correlation_id backward compat."""
+
+    def test_set_and_get(self) -> None:
+        set_correlation_id("corr-abc")
+        assert get_correlation_id() == "corr-abc"
+
+    def test_clear_with_empty_string(self) -> None:
+        set_correlation_id("corr-abc")
         set_correlation_id("")
         assert get_correlation_id() == ""
 
-    def test_set_and_get(self) -> None:
-        set_correlation_id("req-123")
-        assert get_correlation_id() == "req-123"
-        set_correlation_id("")  # cleanup
+    def test_appears_in_request_context(self) -> None:
+        set_correlation_id("corr-xyz")
+        ctx = get_request_context()
+        assert ctx["correlation_id"] == "corr-xyz"
 
-    def test_async_isolation(self) -> None:
-        """Different coroutines get different correlation IDs."""
-        results: dict[str, str] = {}
+    def test_absent_when_empty(self) -> None:
+        set_correlation_id("")
+        ctx = get_request_context()
+        assert "correlation_id" not in ctx
 
-        async def worker(name: str, cid: str) -> None:
-            set_correlation_id(cid)
-            await asyncio.sleep(0.01)
-            results[name] = get_correlation_id()
 
-        async def main() -> None:
-            await asyncio.gather(
-                worker("a", "cid-a"),
-                worker("b", "cid-b"),
-            )
-
-        asyncio.run(main())
-        assert results["a"] == "cid-a"
-        assert results["b"] == "cid-b"
+# ── Setup Logging ───────────────────────────────────────────────────────────
 
 
 class TestSetupLogging:
@@ -139,49 +291,126 @@ class TestSetupLogging:
         root = logging.getLogger()
         assert root.level == logging.INFO
 
-    def test_json_output_contains_required_fields(self, capsys: object) -> None:
+    def test_json_output_contains_required_fields(self) -> None:
         """JSON logs contain required structlog processors."""
         config = LoggingConfig(level="DEBUG", format="json")
         setup_logging(config)
 
-        # Verify structlog processor chain is configured
-        import structlog as _structlog
-
-        cfg = _structlog.get_config()
+        cfg = structlog.get_config()
         processors = cfg["processors"]
         assert len(processors) > 0
 
-        # Verify JSON renderer is on the handler formatter
         root = logging.getLogger()
         handler = root.handlers[0]
         assert handler.formatter is not None
 
-        # Verify actual log goes through without error
         logger = get_logger("test.module")
         logger.info("test event", extra_field="value")
 
-    def test_correlation_id_in_json_output(self) -> None:
-        """JSON output includes correlation_id when set."""
-        config = LoggingConfig(level="DEBUG", format="json")
-        setup_logging(config)
-        set_correlation_id("test-corr-123")
+    def test_processor_chain_includes_merge_contextvars(self) -> None:
+        """merge_contextvars is first in the processor chain."""
+        setup_logging(LoggingConfig(level="DEBUG", format="json"))
+        cfg = structlog.get_config()
+        processors = cfg["processors"]
+        # First processor should be merge_contextvars
+        assert processors[0] is structlog.contextvars.merge_contextvars
 
-        # Verify via processor directly
-        from sovyx.observability.logging import _add_correlation_id
+    def test_processor_chain_includes_secret_masker(self) -> None:
+        """SecretMasker is in the processor chain."""
+        setup_logging(LoggingConfig(level="DEBUG", format="json"))
+        cfg = structlog.get_config()
+        processors = cfg["processors"]
+        masker_found = any(isinstance(p, SecretMasker) for p in processors)
+        assert masker_found
 
-        event_dict: dict[str, object] = {"event": "test"}
-        result = _add_correlation_id(None, "info", event_dict)
-        assert result["correlation_id"] == "test-corr-123"
-        set_correlation_id("")  # cleanup
 
-    def test_correlation_id_absent_when_empty(self) -> None:
-        """No correlation_id field when not set."""
-        from sovyx.observability.logging import _add_correlation_id
+# ── JSON Output Integration ─────────────────────────────────────────────────
 
-        set_correlation_id("")
-        event_dict: dict[str, object] = {"event": "test"}
-        result = _add_correlation_id(None, "info", event_dict)
-        assert "correlation_id" not in result
+
+class TestJSONOutput:
+    """End-to-end JSON log output with structured context."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_json(self) -> None:
+        setup_logging(LoggingConfig(level="DEBUG", format="json"))
+
+    def _capture_log(
+        self,
+        logger: structlog.stdlib.BoundLogger,
+        level: str,
+        event: str,
+        **kw: str,
+    ) -> dict[str, Any]:
+        """Capture a single log line as parsed JSON."""
+        buf = io.StringIO()
+        root = logging.getLogger()
+        handler = root.handlers[0]
+        old_stream = handler.stream
+        handler.stream = buf  # type: ignore[assignment]
+        try:
+            getattr(logger, level)(event, **kw)
+        finally:
+            handler.stream = old_stream  # type: ignore[assignment]
+        line = buf.getvalue().strip()
+        assert line, "No log output captured"
+        return json.loads(line)
+
+    def test_context_fields_in_json(self) -> None:
+        bind_request_context(
+            mind_id="nyx",
+            conversation_id="conv-42",
+            request_id="req-abc",
+        )
+        logger = get_logger("test.json")
+        parsed = self._capture_log(logger, "info", "test_event", extra="val")
+        assert parsed["mind_id"] == "nyx"
+        assert parsed["conversation_id"] == "conv-42"
+        assert parsed["request_id"] == "req-abc"
+        assert parsed["event"] == "test_event"
+        assert parsed["extra"] == "val"
+        assert parsed["level"] == "info"
+        assert "timestamp" in parsed
+
+    def test_no_context_fields_when_unbound(self) -> None:
+        logger = get_logger("test.json")
+        parsed = self._capture_log(logger, "info", "bare_event")
+        assert "mind_id" not in parsed
+        assert "conversation_id" not in parsed
+        # request_id should NOT be present when not bound
+        assert "request_id" not in parsed
+
+    def test_correlation_id_in_json(self) -> None:
+        set_correlation_id("corr-json-test")
+        logger = get_logger("test.json")
+        parsed = self._capture_log(logger, "info", "with_corr")
+        assert parsed["correlation_id"] == "corr-json-test"
+
+    def test_secret_masking_in_json(self) -> None:
+        logger = get_logger("test.json")
+        parsed = self._capture_log(
+            logger, "info", "secret_event", api_key="sk-very-long-secret-key"
+        )
+        assert parsed["api_key"] == "sk-...key"
+
+    def test_bound_context_manager_in_json(self) -> None:
+        logger = get_logger("test.json")
+        with bound_request_context(
+            mind_id="ctx-m", conversation_id="ctx-c", request_id="ctx-r"
+        ):
+            parsed = self._capture_log(logger, "info", "in_ctx")
+        assert parsed["mind_id"] == "ctx-m"
+        assert parsed["request_id"] == "ctx-r"
+
+    def test_timestamp_is_iso(self) -> None:
+        logger = get_logger("test.json")
+        parsed = self._capture_log(logger, "info", "ts_test")
+        ts = parsed["timestamp"]
+        # ISO format: YYYY-MM-DDTHH:MM:SS...
+        assert "T" in ts
+        assert ts.endswith("Z") or "+" in ts or len(ts) > 20
+
+
+# ── GetLogger ───────────────────────────────────────────────────────────────
 
 
 class TestGetLogger:
@@ -199,3 +428,4 @@ class TestGetLogger:
         assert hasattr(logger, "debug")
         assert hasattr(logger, "warning")
         assert hasattr(logger, "error")
+        assert hasattr(logger, "exception")


### PR DESCRIPTION
## OBS-01 — Structured JSON Logging with Request Context

### What changed
- Replace custom `ContextVar` correlation_id with `structlog.contextvars` native API
- New public API: `bind_request_context()` / `clear_request_context()` / `bound_request_context()`
- Auto-inject `mind_id`, `conversation_id`, `request_id` into every log line
- Instrument `CogLoopGate._worker` to bind context per cognitive request
- Backward compat: `set_correlation_id` / `get_correlation_id` still work
- Remove redundant `_add_correlation_id` processor

### Quality
- **46 tests** — 100% coverage on `logging.py`
- **1257 tests passing** (full suite, 0 failures)
- ruff clean, mypy strict clean

### Part of
Sovyx v0.5 — Fase 1: Observability (SPE-026)