### PR TITLE
feat(observability): OBS-03 distributed tracing with OTel spans

### DIFF
--- a/src/sovyx/observability/__init__.py
+++ b/src/sovyx/observability/__init__.py
@@ -1,4 +1,4 @@
-"""Sovyx Observability — Structured logging, request context, metrics."""
+"""Sovyx Observability — Structured logging, request context, metrics, tracing."""
 
 from sovyx.observability.logging import (
     bind_request_context,
@@ -15,9 +15,16 @@ from sovyx.observability.metrics import (
     setup_metrics,
     teardown_metrics,
 )
+from sovyx.observability.tracing import (
+    SovyxTracer,
+    get_tracer,
+    setup_tracing,
+    teardown_tracing,
+)
 
 __all__ = [
     "MetricsRegistry",
+    "SovyxTracer",
     "bind_request_context",
     "bound_request_context",
     "clear_request_context",
@@ -25,7 +32,10 @@ __all__ = [
     "get_logger",
     "get_metrics",
     "get_request_context",
+    "get_tracer",
     "setup_logging",
     "setup_metrics",
+    "setup_tracing",
     "teardown_metrics",
+    "teardown_tracing",
 ]

--- a/src/sovyx/observability/tracing.py
+++ b/src/sovyx/observability/tracing.py
@@ -1,0 +1,252 @@
+"""Sovyx tracing — distributed traces via OpenTelemetry.
+
+Provides spans for the cognitive loop pipeline, LLM calls, brain searches,
+and context assembly.  Each span carries Sovyx-specific attributes
+(mind_id, conversation_id, provider, model, etc.).
+
+Usage::
+
+    from sovyx.observability.tracing import get_tracer
+
+    tracer = get_tracer()
+
+    with tracer.start_cognitive_span("perceive") as span:
+        span.set_attribute("source", "telegram")
+        result = await perceive.process(...)
+
+    # Or use the decorator-style span:
+    with tracer.start_llm_span(provider="anthropic", model="sonnet-4"):
+        response = await provider.generate(...)
+
+Design decisions:
+
+- **Wraps OTel Tracer** — ``SovyxTracer`` delegates to a real OTel Tracer
+  but adds convenience methods with Sovyx-specific attribute schemas.
+- **Lazy / no-op safe** — ``get_tracer()`` returns a ``SovyxTracer`` that
+  wraps whatever the current global TracerProvider gives.  If tracing is
+  not configured, OTel's no-op tracer is used transparently.
+- **Span hierarchy** — ``cognitive_loop`` is the root span; phase spans
+  (perceive, attend, think, act, reflect) are children.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# ── Module constants ────────────────────────────────────────────────────────
+
+_TRACER_NAME = "sovyx"
+_TRACER_VERSION = "0.2.0"
+
+# Valid cognitive phases for span names
+_COGNITIVE_PHASES = frozenset(
+    {"perceive", "attend", "think", "act", "reflect", "consolidate"},
+)
+
+
+# ── SovyxTracer ────────────────────────────────────────────────────────────
+
+
+class SovyxTracer:
+    """Sovyx-specific tracer wrapping an OTel Tracer.
+
+    Provides convenience methods that enforce consistent span naming
+    and attribute schemas across the codebase.
+
+    All ``start_*`` methods return context managers that yield the
+    OTel ``Span`` object for adding custom attributes.
+    """
+
+    def __init__(self, tracer: trace.Tracer) -> None:
+        self._tracer = tracer
+
+    @contextlib.contextmanager
+    def start_cognitive_span(
+        self,
+        phase: str,
+        *,
+        mind_id: str = "",
+        conversation_id: str = "",
+        **attributes: Any,  # noqa: ANN401
+    ) -> Generator[trace.Span, None, None]:
+        """Start a span for a cognitive loop phase.
+
+        Args:
+            phase: One of perceive, attend, think, act, reflect, consolidate.
+            mind_id: The mind being served.
+            conversation_id: Active conversation.
+            **attributes: Extra span attributes.
+
+        Yields:
+            The active OTel Span.
+        """
+        span_name = f"cognitive.{phase}"
+        with self._tracer.start_as_current_span(span_name) as span:
+            if mind_id:
+                span.set_attribute("sovyx.mind_id", mind_id)
+            if conversation_id:
+                span.set_attribute("sovyx.conversation_id", conversation_id)
+            span.set_attribute("sovyx.cognitive.phase", phase)
+            for key, value in attributes.items():
+                span.set_attribute(f"sovyx.{key}", value)
+            yield span
+
+    @contextlib.contextmanager
+    def start_llm_span(
+        self,
+        *,
+        provider: str = "",
+        model: str = "",
+        **attributes: Any,  # noqa: ANN401
+    ) -> Generator[trace.Span, None, None]:
+        """Start a span for an LLM provider call.
+
+        Args:
+            provider: LLM provider name (anthropic, openai, ollama).
+            model: Model identifier.
+            **attributes: Extra span attributes.
+
+        Yields:
+            The active OTel Span.  Callers should set
+            ``tokens_in``, ``tokens_out``, ``cost_usd`` after the call.
+        """
+        with self._tracer.start_as_current_span("llm.call") as span:
+            if provider:
+                span.set_attribute("sovyx.llm.provider", provider)
+            if model:
+                span.set_attribute("sovyx.llm.model", model)
+            for key, value in attributes.items():
+                span.set_attribute(f"sovyx.llm.{key}", value)
+            yield span
+
+    @contextlib.contextmanager
+    def start_brain_span(
+        self,
+        operation: str,
+        **attributes: Any,  # noqa: ANN401
+    ) -> Generator[trace.Span, None, None]:
+        """Start a span for a brain operation.
+
+        Args:
+            operation: e.g. "search", "store_concept", "encode_episode",
+                "consolidate", "spreading_activation".
+            **attributes: Extra span attributes.
+
+        Yields:
+            The active OTel Span.
+        """
+        with self._tracer.start_as_current_span(f"brain.{operation}") as span:
+            for key, value in attributes.items():
+                span.set_attribute(f"sovyx.brain.{key}", value)
+            yield span
+
+    @contextlib.contextmanager
+    def start_context_span(
+        self,
+        **attributes: Any,  # noqa: ANN401
+    ) -> Generator[trace.Span, None, None]:
+        """Start a span for context assembly.
+
+        Args:
+            **attributes: Extra span attributes (e.g. slot_count, budget).
+
+        Yields:
+            The active OTel Span.
+        """
+        with self._tracer.start_as_current_span("context.assembly") as span:
+            for key, value in attributes.items():
+                span.set_attribute(f"sovyx.context.{key}", value)
+            yield span
+
+    @contextlib.contextmanager
+    def start_span(
+        self,
+        name: str,
+        **attributes: Any,  # noqa: ANN401
+    ) -> Generator[trace.Span, None, None]:
+        """Start a generic span with sovyx-prefixed attributes.
+
+        Use for operations that don't fit the specific categories above.
+
+        Args:
+            name: Span name (e.g. "bridge.telegram.send").
+            **attributes: Extra span attributes.
+
+        Yields:
+            The active OTel Span.
+        """
+        with self._tracer.start_as_current_span(name) as span:
+            for key, value in attributes.items():
+                span.set_attribute(f"sovyx.{key}", value)
+            yield span
+
+
+# ── Setup / Get ─────────────────────────────────────────────────────────────
+
+_active_provider: TracerProvider | None = None
+
+
+def setup_tracing(
+    *,
+    exporters: list[SpanExporter] | None = None,
+    service_name: str = "sovyx",
+) -> SovyxTracer:
+    """Initialize the OTel tracing pipeline.
+
+    Call once at application startup.
+
+    Args:
+        exporters: List of SpanExporters.  If ``None``, tracing is
+            configured with no exporters (spans are created but not
+            exported — useful for testing with ``get_finished_spans``
+            on the provider).
+        service_name: OTel service name attribute.
+
+    Returns:
+        A configured :class:`SovyxTracer`.
+    """
+    global _active_provider  # noqa: PLW0603
+
+    from opentelemetry.sdk.resources import Resource
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+
+    if exporters:
+        for exporter in exporters:
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    trace.set_tracer_provider(provider)
+    _active_provider = provider
+
+    return SovyxTracer(provider.get_tracer(_TRACER_NAME, _TRACER_VERSION))
+
+
+def teardown_tracing() -> None:
+    """Shut down the tracing pipeline."""
+    global _active_provider  # noqa: PLW0603
+
+    if _active_provider is not None:
+        _active_provider.shutdown()
+        _active_provider = None
+
+
+def get_tracer() -> SovyxTracer:
+    """Return a SovyxTracer using the current global TracerProvider.
+
+    Safe to call at any time — if tracing isn't configured, OTel's
+    no-op tracer is returned transparently.
+    """
+    otel_tracer = trace.get_tracer(_TRACER_NAME, _TRACER_VERSION)
+    return SovyxTracer(otel_tracer)

--- a/tests/unit/observability/test_tracing.py
+++ b/tests/unit/observability/test_tracing.py
@@ -1,0 +1,432 @@
+"""Tests for sovyx.observability.tracing — OTel spans for cognitive pipeline."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from opentelemetry.sdk.trace.export import (
+    SpanExporter,
+    SpanExportResult,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace import ReadableSpan
+
+from sovyx.observability.tracing import (
+    SovyxTracer,
+    get_tracer,
+    setup_tracing,
+    teardown_tracing,
+)
+
+# ── In-memory span collector ───────────────────────────────────────────────
+
+
+class InMemoryExporter(SpanExporter):
+    """Collects finished spans in a list for test assertions."""
+
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans: Any) -> SpanExportResult:  # noqa: ANN401
+        """Store exported spans."""
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        """No-op."""
+
+    def force_flush(self, timeout_millis: int = 0) -> bool:
+        """No-op flush."""
+        return True
+
+    def clear(self) -> None:
+        """Clear collected spans."""
+        self.spans.clear()
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel_trace() -> None:
+    """Reset OTel global tracer state between tests."""
+    from opentelemetry.trace import _TRACER_PROVIDER_SET_ONCE
+
+    yield  # type: ignore[misc]
+    teardown_tracing()
+    _TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+
+
+@pytest.fixture()
+def exporter() -> InMemoryExporter:
+    """Fresh in-memory span exporter."""
+    return InMemoryExporter()
+
+
+@pytest.fixture()
+def tracer(exporter: InMemoryExporter) -> SovyxTracer:
+    """Set up tracing with in-memory exporter."""
+    return setup_tracing(exporters=[exporter])
+
+
+# ── Setup / Teardown ────────────────────────────────────────────────────────
+
+
+class TestSetupTeardown:
+    """Tracing lifecycle."""
+
+    def test_setup_returns_sovyx_tracer(self, exporter: InMemoryExporter) -> None:
+        t = setup_tracing(exporters=[exporter])
+        assert isinstance(t, SovyxTracer)
+
+    def test_get_tracer_returns_sovyx_tracer(
+        self,
+        tracer: SovyxTracer,
+    ) -> None:
+        t = get_tracer()
+        assert isinstance(t, SovyxTracer)
+
+    def test_teardown_cleans_up(self, exporter: InMemoryExporter) -> None:
+        setup_tracing(exporters=[exporter])
+        teardown_tracing()
+        # Should not raise; get_tracer returns no-op based tracer
+        t = get_tracer()
+        assert isinstance(t, SovyxTracer)
+
+    def test_setup_without_exporters(self) -> None:
+        """No exporters = spans created but not exported."""
+        t = setup_tracing()
+        assert isinstance(t, SovyxTracer)
+
+
+# ── Cognitive Spans ─────────────────────────────────────────────────────────
+
+
+class TestCognitiveSpan:
+    """start_cognitive_span creates correct spans."""
+
+    def test_creates_span_with_phase(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_cognitive_span("perceive"):
+            pass
+
+        assert len(exporter.spans) == 1
+        span = exporter.spans[0]
+        assert span.name == "cognitive.perceive"
+        attrs = dict(span.attributes or {})
+        assert attrs["sovyx.cognitive.phase"] == "perceive"
+
+    def test_includes_mind_id_and_conversation_id(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_cognitive_span(
+            "think",
+            mind_id="nyx",
+            conversation_id="conv-42",
+        ):
+            pass
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert attrs["sovyx.mind_id"] == "nyx"
+        assert attrs["sovyx.conversation_id"] == "conv-42"
+
+    def test_extra_attributes(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_cognitive_span(
+            "act",
+            person_name="Guipe",
+        ):
+            pass
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert attrs["sovyx.person_name"] == "Guipe"
+
+    def test_omits_empty_mind_id(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_cognitive_span("attend"):
+            pass
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert "sovyx.mind_id" not in attrs
+
+    def test_span_set_attribute_inside(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        """Can add attributes inside the context manager."""
+        with tracer.start_cognitive_span("reflect") as span:
+            span.set_attribute("sovyx.tokens_in", 500)
+            span.set_attribute("sovyx.tokens_out", 150)
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert attrs["sovyx.tokens_in"] == 500
+        assert attrs["sovyx.tokens_out"] == 150
+
+    def test_span_records_exception(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        """Spans auto-record exceptions when body raises."""
+        with (
+            pytest.raises(ValueError, match="test error"),
+            tracer.start_cognitive_span("think"),
+        ):
+            raise ValueError("test error")
+
+        span = exporter.spans[0]
+        # OTel records the exception as an event
+        events = span.events
+        assert len(events) >= 1
+        assert events[0].name == "exception"
+
+    def test_all_phases(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        """All cognitive phases create valid spans."""
+        phases = ["perceive", "attend", "think", "act", "reflect", "consolidate"]
+        for phase in phases:
+            with tracer.start_cognitive_span(phase):
+                pass
+
+        assert len(exporter.spans) == 6
+        names = [s.name for s in exporter.spans]
+        for phase in phases:
+            assert f"cognitive.{phase}" in names
+
+
+# ── LLM Spans ──────────────────────────────────────────────────────────────
+
+
+class TestLLMSpan:
+    """start_llm_span for provider calls."""
+
+    def test_creates_llm_span(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_llm_span(provider="anthropic", model="claude-sonnet"):
+            pass
+
+        span = exporter.spans[0]
+        assert span.name == "llm.call"
+        attrs = dict(span.attributes or {})
+        assert attrs["sovyx.llm.provider"] == "anthropic"
+        assert attrs["sovyx.llm.model"] == "claude-sonnet"
+
+    def test_set_response_attributes(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_llm_span(provider="openai") as span:
+            span.set_attribute("sovyx.llm.tokens_in", 1000)
+            span.set_attribute("sovyx.llm.tokens_out", 200)
+            span.set_attribute("sovyx.llm.cost_usd", 0.003)
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert attrs["sovyx.llm.tokens_in"] == 1000
+        assert attrs["sovyx.llm.cost_usd"] == 0.003
+
+    def test_omits_empty_provider(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_llm_span():
+            pass
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert "sovyx.llm.provider" not in attrs
+
+    def test_extra_llm_attributes(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_llm_span(provider="ollama", temperature=0.7):
+            pass
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert attrs["sovyx.llm.temperature"] == 0.7
+
+
+# ── Brain Spans ─────────────────────────────────────────────────────────────
+
+
+class TestBrainSpan:
+    """start_brain_span for brain operations."""
+
+    def test_search_span(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_brain_span("search", query="python asyncio"):
+            pass
+
+        span = exporter.spans[0]
+        assert span.name == "brain.search"
+        attrs = dict(span.attributes or {})
+        assert attrs["sovyx.brain.query"] == "python asyncio"
+
+    def test_store_concept_span(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_brain_span("store_concept", concept_id="c-123"):
+            pass
+
+        assert exporter.spans[0].name == "brain.store_concept"
+
+    def test_spreading_activation_span(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_brain_span("spreading_activation", depth=3):
+            pass
+
+        attrs = dict(exporter.spans[0].attributes or {})
+        assert attrs["sovyx.brain.depth"] == 3
+
+
+# ── Context Assembly Spans ──────────────────────────────────────────────────
+
+
+class TestContextSpan:
+    """start_context_span for context assembly."""
+
+    def test_context_assembly_span(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_context_span(slot_count=6, budget=4096):
+            pass
+
+        span = exporter.spans[0]
+        assert span.name == "context.assembly"
+        attrs = dict(span.attributes or {})
+        assert attrs["sovyx.context.slot_count"] == 6
+        assert attrs["sovyx.context.budget"] == 4096
+
+
+# ── Generic Spans ───────────────────────────────────────────────────────────
+
+
+class TestGenericSpan:
+    """start_span for arbitrary operations."""
+
+    def test_generic_span(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        with tracer.start_span("bridge.telegram.send", chat_id="12345"):
+            pass
+
+        span = exporter.spans[0]
+        assert span.name == "bridge.telegram.send"
+        attrs = dict(span.attributes or {})
+        assert attrs["sovyx.chat_id"] == "12345"
+
+
+# ── Span Hierarchy ──────────────────────────────────────────────────────────
+
+
+class TestSpanHierarchy:
+    """Nested spans create parent-child relationships."""
+
+    def test_nested_spans(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        """Child spans reference parent's span context."""
+        with tracer.start_cognitive_span("think", mind_id="nyx"):  # noqa: SIM117
+            with tracer.start_llm_span(provider="anthropic"):
+                pass
+
+        assert len(exporter.spans) == 2
+        # LLM span finished first (inner), cognitive span finished second (outer)
+        llm_span = exporter.spans[0]
+        think_span = exporter.spans[1]
+
+        assert think_span.name == "cognitive.think"
+        assert llm_span.name == "llm.call"
+
+        # LLM span should be child of think span
+        assert llm_span.parent is not None
+        assert llm_span.parent.span_id == think_span.context.span_id
+
+    def test_full_pipeline_hierarchy(
+        self,
+        tracer: SovyxTracer,
+        exporter: InMemoryExporter,
+    ) -> None:
+        """Simulates a full cognitive loop with nested spans."""
+        with tracer.start_span("cognitive.loop"):
+            with tracer.start_cognitive_span("perceive"):
+                pass
+            with tracer.start_cognitive_span("attend"):
+                pass
+            with tracer.start_cognitive_span("think"):
+                with tracer.start_context_span():
+                    pass
+                with tracer.start_llm_span(provider="anthropic"):
+                    pass
+            with tracer.start_cognitive_span("act"):
+                pass
+            with tracer.start_cognitive_span("reflect"):  # noqa: SIM117
+                with tracer.start_brain_span("encode_episode"):
+                    pass
+
+        # 9 spans total: loop + 5 phases + context + llm + brain
+        assert len(exporter.spans) == 9
+
+        # Root span is the last to finish
+        root = exporter.spans[-1]
+        assert root.name == "cognitive.loop"
+        assert root.parent is None
+
+        # All others are descendants
+        for span in exporter.spans[:-1]:
+            assert span.parent is not None
+
+
+# ── No-op safety ────────────────────────────────────────────────────────────
+
+
+class TestNoOpSafety:
+    """get_tracer works even without setup (no-op tracer)."""
+
+    def test_get_tracer_without_setup(self) -> None:
+        """Should not raise — uses OTel no-op tracer."""
+        t = get_tracer()
+        with t.start_cognitive_span("think"):
+            pass  # no-op, no error
+
+    def test_noop_span_attribute_safe(self) -> None:
+        """Setting attributes on no-op spans doesn't raise."""
+        t = get_tracer()
+        with t.start_llm_span(provider="test") as span:
+            span.set_attribute("key", "value")


### PR DESCRIPTION
## OBS-03 — Distributed Tracing (OpenTelemetry)

### What's new
- `SovyxTracer` — wraps OTel Tracer with Sovyx-specific convenience methods
- `start_cognitive_span(phase)` — perceive/attend/think/act/reflect/consolidate
- `start_llm_span(provider, model)` — LLM provider calls
- `start_brain_span(operation)` — search, store_concept, encode_episode
- `start_context_span()` — context assembly
- `start_span(name)` — generic operations
- Automatic parent-child span hierarchy via OTel context propagation
- Exception auto-recording on span events
- No-op safe — works without setup
- `setup_tracing()` / `teardown_tracing()` lifecycle

### Quality
- **24 tests** — 100% coverage on tracing.py
- **1309 tests passing** (full suite)
- ruff clean, mypy strict clean

### Part of
Sovyx v0.5 — Fase 1: Observability (SPE-026)