### PR TITLE
fix(observability): review-v2 — 5 inconsistencies resolved

### DIFF
--- a/src/sovyx/observability/logging.py
+++ b/src/sovyx/observability/logging.py
@@ -214,6 +214,18 @@ def setup_logging(config: LoggingConfig) -> None:
     """
     global _setup_done  # noqa: PLW0603
 
+    # Guard: close existing file handlers before reconfiguring.
+    # Prevents file descriptor leaks on repeated setup_logging() calls
+    # (common in tests, hot-reload, or daemon reconfiguration).
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            handler.close()
+
+    # Reset structlog cache so new config takes effect on all loggers.
+    if _setup_done:
+        structlog.reset_defaults()
+
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_log_level,

--- a/src/sovyx/observability/metrics.py
+++ b/src/sovyx/observability/metrics.py
@@ -9,7 +9,8 @@ Usage::
     from sovyx.observability.metrics import get_metrics
 
     m = get_metrics()
-    m.messages_processed.add(1, {"channel": "telegram"})
+    m.messages_received.add(1, {"channel": "telegram"})
+    m.messages_processed.add(1, {"mind_id": "nyx"})
 
     with m.measure_latency(m.llm_response_latency):
         response = await provider.generate(...)
@@ -58,7 +59,8 @@ class MetricsRegistry:
     and reused for the lifetime of the application.
 
     Attributes (Counters):
-        messages_processed: Total messages processed by the cognitive loop.
+        messages_received: Messages received from channels (label: channel).
+        messages_processed: Messages fully processed through cognitive loop (label: mind_id).
         llm_calls: Total LLM provider calls (label: provider, model).
         errors: Total errors by category (label: error_type, module).
         tokens_used: Total tokens consumed (label: direction=in|out, provider).

--- a/src/sovyx/observability/tracing.py
+++ b/src/sovyx/observability/tracing.py
@@ -49,12 +49,6 @@ if TYPE_CHECKING:
 _TRACER_NAME = "sovyx"
 _TRACER_VERSION = "0.2.0"
 
-# Valid cognitive phases for span names
-_COGNITIVE_PHASES = frozenset(
-    {"perceive", "attend", "think", "act", "reflect", "consolidate"},
-)
-
-
 # ── SovyxTracer ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/observability/test_logging.py
+++ b/tests/unit/observability/test_logging.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import logging.handlers
+from collections.abc import Generator  # noqa: TC003
 from pathlib import Path  # noqa: TC003
 from typing import Any
 
@@ -431,6 +432,16 @@ class TestGetLogger:
 class TestFileHandler:
     """setup_logging with log_file creates a RotatingFileHandler."""
 
+    @pytest.fixture(autouse=True)
+    def _cleanup_handlers(self) -> Generator[None, None, None]:
+        """Close and remove file handlers after each test."""
+        yield
+        root = logging.getLogger()
+        for handler in list(root.handlers):
+            if isinstance(handler, logging.handlers.RotatingFileHandler):
+                handler.close()
+                root.removeHandler(handler)
+
     def test_creates_log_file(self, tmp_path: Path) -> None:
         log_file = tmp_path / "logs" / "test.log"
         config = LoggingConfig(level="DEBUG", format="json", log_file=log_file)
@@ -474,6 +485,24 @@ class TestFileHandler:
         assert len(file_handlers) == 1
         assert file_handlers[0].maxBytes == 10 * 1024 * 1024
         assert file_handlers[0].backupCount == 3
+
+    def test_repeated_setup_closes_old_handlers(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "test.log"
+        config = LoggingConfig(level="DEBUG", format="json", log_file=log_file)
+
+        # Call setup_logging twice
+        setup_logging(config)
+        setup_logging(config)
+
+        # Should still only have 2 handlers (not 3 or 4)
+        root = logging.getLogger()
+        assert len(root.handlers) == 2  # 1 stderr + 1 file
+
+        # File handlers specifically
+        file_handlers = [
+            h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
+        ]
+        assert len(file_handlers) == 1
 
     def test_no_file_handler_when_none(self) -> None:
         config = LoggingConfig(level="INFO", format="json", log_file=None)


### PR DESCRIPTION
## Second Review Pass

5 issues found and fixed:

| # | Issue | Fix |
|---|-------|-----|
| 1 | `_setup_done` flag set but never checked | Now guards `structlog.reset_defaults()` + closes old file handlers |
| 2 | `_COGNITIVE_PHASES` dead code in tracing.py | Removed |
| 3 | metrics.py Usage example outdated | Updated to show `messages_received`/`messages_processed` |
| 4 | `messages_received` missing from class docstring | Added |
| 5 | File handler FD leaks in tests | Cleanup fixture + re-entrancy test |

### Tests
- **1438 passed** (full suite)
- New test: `test_repeated_setup_closes_old_handlers` proves no handler accumulation