### PR TITLE
fix(observability): review-v4 — crash bug + logic bug

### DIFF
--- a/src/sovyx/cli/commands/logs.py
+++ b/src/sovyx/cli/commands/logs.py
@@ -100,10 +100,13 @@ def _matches(
         if isinstance(ts, str) and ts:
             try:
                 entry_time = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                # Assume UTC for naive timestamps (no timezone info)
+                if entry_time.tzinfo is None:
+                    entry_time = entry_time.replace(tzinfo=UTC)
                 if entry_time < since:
                     return False
-            except ValueError:
-                pass  # Can't parse → include it
+            except (ValueError, TypeError):
+                pass  # Can't parse or compare → include it
 
     # Key=value filters
     for key, value in filters.items():

--- a/src/sovyx/observability/health.py
+++ b/src/sovyx/observability/health.py
@@ -542,7 +542,11 @@ class CostBudgetCheck(HealthCheck):
             )
         try:
             spend = self._get_spend_fn()
-            pct = (spend / self._daily_budget * 100) if self._daily_budget > 0 else 0
+            if self._daily_budget <= 0:
+                # Zero or negative budget: any spend is over budget
+                pct = 100.0 if spend > 0 else 0.0
+            else:
+                pct = spend / self._daily_budget * 100
             meta = {
                 "daily_spend": round(spend, 4),
                 "daily_budget": self._daily_budget,

--- a/src/sovyx/observability/metrics.py
+++ b/src/sovyx/observability/metrics.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
 # ── Metrics Registry ────────────────────────────────────────────────────────
 
 _METER_NAME = "sovyx"
+# Tracks the observability API version (not the package version in pyproject.toml).
+# Bump when instrument names, units, or attribute schemas change.
 _METER_VERSION = "0.2.0"
 
 # Module-level reference set by setup_metrics / reset by teardown_metrics.

--- a/src/sovyx/observability/tracing.py
+++ b/src/sovyx/observability/tracing.py
@@ -47,6 +47,8 @@ if TYPE_CHECKING:
 # ── Module constants ────────────────────────────────────────────────────────
 
 _TRACER_NAME = "sovyx"
+# Tracks the observability API version (not the package version in pyproject.toml).
+# Bump when span names, attribute schemas, or namespace conventions change.
 _TRACER_VERSION = "0.2.0"
 
 # ── SovyxTracer ────────────────────────────────────────────────────────────

--- a/tests/unit/cli/test_logs.py
+++ b/tests/unit/cli/test_logs.py
@@ -151,6 +151,22 @@ class TestMatches:
         since = datetime.now(tz=UTC) - timedelta(hours=1)
         assert _matches(entry, level_min=None, filters={}, since=since) is True
 
+    def test_since_with_naive_timestamp_assumes_utc(self) -> None:
+        """Naive timestamps (no tz) should be treated as UTC, not crash."""
+        now = datetime.now(tz=UTC)
+        # Recent naive timestamp — should be included
+        recent_naive = now.strftime("%Y-%m-%dT%H:%M:%S")  # no timezone
+        entry = {"event": "test", "timestamp": recent_naive}
+        since = now - timedelta(hours=1)
+        assert _matches(entry, level_min=None, filters={}, since=since) is True
+
+    def test_since_with_old_naive_timestamp_excluded(self) -> None:
+        """Old naive timestamps should be correctly excluded."""
+        old = datetime.now(tz=UTC) - timedelta(hours=2)
+        entry = {"event": "test", "timestamp": old.strftime("%Y-%m-%dT%H:%M:%S")}
+        since = datetime.now(tz=UTC) - timedelta(hours=1)
+        assert _matches(entry, level_min=None, filters={}, since=since) is False
+
     def test_combined_filters(self) -> None:
         now = datetime.now(tz=UTC)
         entry = {

--- a/tests/unit/observability/test_health.py
+++ b/tests/unit/observability/test_health.py
@@ -477,9 +477,15 @@ class TestCostBudgetCheck:
         assert result.status == CheckStatus.YELLOW
 
     @pytest.mark.asyncio()
-    async def test_zero_budget(self) -> None:
+    async def test_zero_budget_zero_spend(self) -> None:
         result = await CostBudgetCheck(get_spend_fn=lambda: 0.0, daily_budget=0.0).check()
         assert result.status == CheckStatus.GREEN
+
+    @pytest.mark.asyncio()
+    async def test_zero_budget_with_spend_is_red(self) -> None:
+        """Any spend with zero budget should be RED (over budget)."""
+        result = await CostBudgetCheck(get_spend_fn=lambda: 0.5, daily_budget=0.0).check()
+        assert result.status == CheckStatus.RED
 
     @pytest.mark.asyncio()
     async def test_red_on_exception(self) -> None:


### PR DESCRIPTION
## Fourth Review Pass — Changed Methodology

Instead of reading code, ran **automated edge case testing** against every public function.

### Bugs Found & Fixed

| Severity | Issue | Fix |
|----------|-------|-----|
| 🔴 **CRASH** | `_matches` raises `TypeError` on naive timestamps with `--since` | Assume UTC for naive; catch `TypeError` |
| 🟡 **LOGIC** | `CostBudgetCheck` returns GREEN when budget=$0 but spend>$0 | Zero budget + any spend = RED |
| 📝 **DOCS** | `_METER_VERSION`/`_TRACER_VERSION` diverge from pyproject version | Added comments explaining intentional divergence |

### Verification
Tested 9 timestamp variants, 5 CostBudget edge cases, all format edge cases.
**1443 tests passed.**