### PR TITLE
fix(observability): review-v5 — adversarial testing (118 edge cases)

### DIFF
--- a/src/sovyx/observability/health.py
+++ b/src/sovyx/observability/health.py
@@ -160,7 +160,14 @@ class DiskSpaceCheck(HealthCheck):
         return "Disk Space"
 
     async def check(self) -> CheckResult:
-        usage = shutil.disk_usage(self._path)
+        try:
+            usage = shutil.disk_usage(self._path)
+        except (FileNotFoundError, OSError) as exc:
+            return CheckResult(
+                name=self.name,
+                status=CheckStatus.RED,
+                message=f"Cannot check disk: {exc}",
+            )
         free_gb = usage.free / (1024**3)
         meta = {
             "free_gb": round(free_gb, 2),

--- a/src/sovyx/observability/metrics.py
+++ b/src/sovyx/observability/metrics.py
@@ -191,13 +191,21 @@ class _NoOpRegistry:
     """
 
     class _NoOpInstrument:
-        """No-op instrument that accepts any call."""
+        """No-op instrument that accepts any call.
+
+        Also handles chained attribute access (e.g. ``noop.a.b``)
+        by returning itself for any unknown attribute.
+        """
 
         def add(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             """No-op add."""
 
         def record(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
             """No-op record."""
+
+        def __getattr__(self, name: str) -> _NoOpRegistry._NoOpInstrument:
+            """Return self for any attribute access — safe chaining."""
+            return self
 
     _noop = _NoOpInstrument()
 

--- a/tests/unit/observability/test_health.py
+++ b/tests/unit/observability/test_health.py
@@ -204,6 +204,14 @@ class TestDiskSpaceCheck:
     def test_name(self) -> None:
         assert DiskSpaceCheck().name == "Disk Space"
 
+    @pytest.mark.asyncio()
+    async def test_nonexistent_path_returns_red(self) -> None:
+        """DiskSpaceCheck with nonexistent path returns RED, not crash."""
+        check = DiskSpaceCheck(path=Path("/nonexistent/path/xyz"))
+        result = await check.check()
+        assert result.status == CheckStatus.RED
+        assert "Cannot check disk" in result.message
+
 
 # ── RAMCheck ────────────────────────────────────────────────────────────────
 

--- a/tests/unit/observability/test_metrics.py
+++ b/tests/unit/observability/test_metrics.py
@@ -351,6 +351,13 @@ class TestNoOpRegistry:
         instrument.add(1)  # should not raise
         instrument.record(42.0)  # should not raise
 
+    def test_chained_attr_access(self) -> None:
+        """Chained attribute access (noop.a.b.c) should not crash."""
+        noop = _NoOpRegistry()
+        noop.a.b  # noqa: B018
+        noop.x.y.z.add(1)  # should not raise
+        noop.deep.nested.attr.record(42.0)  # should not raise
+
 
 # ── collect_json ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Fifth Review Pass — Adversarial Testing

Ran **118 automated edge case tests** against all public observability functions.

### Inputs tested per function:
`None`, empty strings, unicode (🔮, 日本語), very long strings (10K chars),
negative numbers, `NaN`, `inf`, nonexistent paths, chained attributes,
type-mismatched inputs, zero values, boundary values.

### Bugs Found & Fixed

| # | Bug | Impact | Fix |
|---|-----|--------|-----|
| 1 | `_NoOpInstrument` crashes on `noop.a.b` | Low — no production call site uses this | Added `__getattr__` returning self |
| 2 | `DiskSpaceCheck` crashes on nonexistent path | Medium — `_safe_run` catches it but direct `check()` crashes | Try/except for `FileNotFoundError`/`OSError` |

### Tests
- **1445 passed** (full suite)
- **116/118 adversarial edge cases passed** (2 fixed)