### PR TITLE
feat(dashboard): PREP-06 routing — breadcrumbs, page transitions, 404

### DIFF
--- a/dashboard/src/components/layout/app-layout.tsx
+++ b/dashboard/src/components/layout/app-layout.tsx
@@ -1,12 +1,17 @@
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
+import { AnimatePresence } from "framer-motion";
 import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { AppSidebar } from "./app-sidebar";
+import { Breadcrumb } from "./breadcrumb";
+import { PageTransition } from "./page-transition";
 import { useWebSocket } from "@/hooks/use-websocket";
 
 export function AppLayout() {
+  const location = useLocation();
+
   // Connect WebSocket at layout level (stays alive across page navigations)
   useWebSocket();
 
@@ -18,23 +23,18 @@ export function AppLayout() {
           <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
             <SidebarTrigger className="-ml-1" />
             <Separator orientation="vertical" className="mr-2 h-4" />
-            <PageBreadcrumb />
+            <Breadcrumb />
           </header>
           <main className="flex-1 overflow-auto p-4 md:p-6">
-            <Outlet />
+            <AnimatePresence mode="wait">
+              <PageTransition key={location.pathname}>
+                <Outlet />
+              </PageTransition>
+            </AnimatePresence>
           </main>
         </SidebarInset>
       </SidebarProvider>
       <Toaster />
     </TooltipProvider>
-  );
-}
-
-function PageBreadcrumb() {
-  // Simple breadcrumb — will be enhanced per-page later
-  return (
-    <nav className="text-sm text-muted-foreground">
-      <span className="font-medium text-foreground">Sovyx Dashboard</span>
-    </nav>
   );
 }

--- a/dashboard/src/components/layout/breadcrumb.tsx
+++ b/dashboard/src/components/layout/breadcrumb.tsx
@@ -1,0 +1,61 @@
+import { useLocation, Link } from "react-router";
+import {
+  LayoutDashboard,
+  MessageSquare,
+  Brain,
+  ScrollText,
+  Settings,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface RouteInfo {
+  label: string;
+  icon: LucideIcon;
+}
+
+const ROUTE_MAP: Record<string, RouteInfo> = {
+  "/": { label: "Overview", icon: LayoutDashboard },
+  "/conversations": { label: "Conversations", icon: MessageSquare },
+  "/brain": { label: "Brain Explorer", icon: Brain },
+  "/logs": { label: "Logs", icon: ScrollText },
+  "/settings": { label: "Settings", icon: Settings },
+};
+
+export function Breadcrumb() {
+  const location = useLocation();
+  const route = ROUTE_MAP[location.pathname];
+
+  if (!route) {
+    return (
+      <nav className="flex items-center gap-2 text-sm">
+        <Link to="/" className="text-muted-foreground hover:text-foreground transition-colors">
+          Sovyx
+        </Link>
+        <span className="text-muted-foreground">/</span>
+        <span className="text-foreground">Not Found</span>
+      </nav>
+    );
+  }
+
+  const Icon = route.icon;
+
+  return (
+    <nav className="flex items-center gap-2 text-sm">
+      {location.pathname !== "/" && (
+        <>
+          <Link
+            to="/"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Sovyx
+          </Link>
+          <span className="text-muted-foreground">/</span>
+        </>
+      )}
+      <div className="flex items-center gap-1.5">
+        <Icon className="size-3.5 text-muted-foreground" />
+        <span className="font-medium text-foreground">{route.label}</span>
+      </div>
+    </nav>
+  );
+}

--- a/dashboard/src/components/layout/page-transition.tsx
+++ b/dashboard/src/components/layout/page-transition.tsx
@@ -1,0 +1,26 @@
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+interface PageTransitionProps {
+  children: ReactNode;
+}
+
+const variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -8 },
+};
+
+export function PageTransition({ children }: PageTransitionProps) {
+  return (
+    <motion.div
+      variants={variants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={{ duration: 0.2, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/dashboard/src/pages/not-found.tsx
+++ b/dashboard/src/pages/not-found.tsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router";
+import { Button } from "@/components/ui/button";
+import { Home } from "lucide-react";
+
+export default function NotFoundPage() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+      <div className="text-6xl">🔮</div>
+      <h1 className="text-3xl font-bold">404</h1>
+      <p className="text-muted-foreground">
+        This page doesn&apos;t exist in Sovyx&apos;s memory.
+      </p>
+      <Button render={<Link to="/" />}>
+        <Home className="mr-2 size-4" />
+        Back to Overview
+      </Button>
+    </div>
+  );
+}

--- a/dashboard/src/router.tsx
+++ b/dashboard/src/router.tsx
@@ -9,15 +9,20 @@ const ConversationsPage = lazy(() => import("@/pages/conversations"));
 const BrainPage = lazy(() => import("@/pages/brain"));
 const LogsPage = lazy(() => import("@/pages/logs"));
 const SettingsPage = lazy(() => import("@/pages/settings"));
+const NotFoundPage = lazy(() => import("@/pages/not-found"));
 
 function PageSuspense({ children }: { children: React.ReactNode }) {
   return (
     <Suspense
       fallback={
-        <div className="space-y-4 p-4">
+        <div className="space-y-4">
           <Skeleton className="h-8 w-48" />
-          <Skeleton className="h-32 w-full" />
-          <Skeleton className="h-32 w-full" />
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+            <Skeleton className="h-32" />
+          </div>
+          <Skeleton className="h-48 w-full" />
         </div>
       }
     >
@@ -67,6 +72,14 @@ export const router = createBrowserRouter([
         element: (
           <PageSuspense>
             <SettingsPage />
+          </PageSuspense>
+        ),
+      },
+      {
+        path: "*",
+        element: (
+          <PageSuspense>
+            <NotFoundPage />
           </PageSuspense>
         ),
       },


### PR DESCRIPTION
## PREP-06: Routing Refinements

### What
- **Breadcrumb**: dynamic icon + label per route, link back to overview
- **PageTransition**: framer-motion fade+slide (200ms), AnimatePresence wait mode
- **404 page**: Sovyx branding, back-to-overview button
- **Catch-all route**: `*` → NotFoundPage
- **Improved skeleton**: mimics 3-column card layout during lazy load

### Validations
- `tsc --noEmit` ✅
- `eslint` ✅
- `vite build` ✅

Part of SOVYX-DASH-DESIGN-MISSION