### PR TITLE
feat(dashboard): DASH-01 integrate server into Engine lifecycle + CLI

### DIFF
--- a/src/sovyx/cli/commands/dashboard.py
+++ b/src/sovyx/cli/commands/dashboard.py
@@ -1,0 +1,60 @@
+"""CLI command: sovyx dashboard — show dashboard access info."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from sovyx.dashboard.server import TOKEN_FILE
+
+console = Console()
+dashboard_app = typer.Typer(help="Dashboard management")
+
+
+@dashboard_app.callback(invoke_without_command=True)
+def dashboard_info(
+    ctx: typer.Context,
+    show_token: bool = typer.Option(False, "--token", "-t", help="Show the auth token"),
+) -> None:
+    """Show dashboard access information."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    # Read config for host/port (defaults)
+    host = "127.0.0.1"
+    port = 7777
+
+    config_path = Path.home() / ".sovyx" / "system.yaml"
+    if config_path.exists():
+        try:
+            import yaml
+
+            with config_path.open() as f:
+                cfg = yaml.safe_load(f) or {}
+            api_cfg = cfg.get("api", {})
+            host = api_cfg.get("host", host)
+            port = api_cfg.get("port", port)
+        except Exception:  # noqa: BLE001
+            pass
+
+    url = f"http://{host}:{port}"
+
+    console.print()
+    console.print("[bold]🔮 Sovyx Dashboard[/bold]")
+    console.print()
+    console.print(f"  URL:   [link={url}]{url}[/link]")
+
+    if show_token:
+        if TOKEN_FILE.exists():
+            token = TOKEN_FILE.read_text().strip()
+            console.print(f"  Token: [dim]{token}[/dim]")
+        else:
+            console.print("  Token: [yellow]Not generated yet (start sovyx first)[/yellow]")
+    else:
+        console.print("  Token: [dim]use --token to reveal[/dim]")
+
+    console.print()
+    console.print("[dim]Start the daemon with 'sovyx start' to access the dashboard.[/dim]")
+    console.print()

--- a/src/sovyx/cli/main.py
+++ b/src/sovyx/cli/main.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from sovyx import __version__
+from sovyx.cli.commands.dashboard import dashboard_app
 from sovyx.cli.commands.logs import logs_app
 from sovyx.cli.rpc_client import DaemonClient
 
@@ -24,6 +25,7 @@ mind_app = typer.Typer(name="mind", help="Mind management commands")
 app.add_typer(brain_app)
 app.add_typer(mind_app)
 app.add_typer(logs_app)
+app.add_typer(dashboard_app, name="dashboard")
 
 
 def _get_client() -> DaemonClient:

--- a/src/sovyx/engine/lifecycle.py
+++ b/src/sovyx/engine/lifecycle.py
@@ -128,6 +128,9 @@ class LifecycleManager:
         # Start services in order
         await self._start_services()
 
+        # Start dashboard server (if API enabled)
+        await self._start_dashboard()
+
         # Emit engine started
         from sovyx.engine.events import EngineStarted
 
@@ -180,6 +183,31 @@ class LifecycleManager:
         logger.info("signal_received", signal=sig.name)
         self._shutdown_event.set()
 
+    async def _start_dashboard(self) -> None:
+        """Start the dashboard server if API is enabled in config."""
+        from sovyx.dashboard.server import DashboardServer
+        from sovyx.engine.config import APIConfig, EngineConfig
+
+        config: APIConfig | None = None
+        if self._registry.is_registered(EngineConfig):
+            engine_config = await self._registry.resolve(EngineConfig)
+            if not engine_config.api.enabled:
+                logger.info("dashboard_disabled")
+                return
+            config = engine_config.api
+
+        server = DashboardServer(config=config)
+        await server.start()
+        self._registry.register_instance(DashboardServer, server)
+
+    async def _stop_dashboard(self) -> None:
+        """Stop the dashboard server if running."""
+        from sovyx.dashboard.server import DashboardServer
+
+        if self._registry.is_registered(DashboardServer):
+            server = await self._registry.resolve(DashboardServer)
+            await server.stop()
+
     async def _start_services(self) -> None:
         """Start services that have start() methods."""
         from sovyx.bridge.manager import BridgeManager
@@ -204,10 +232,13 @@ class LifecycleManager:
     async def _shutdown_services(self) -> None:
         """Stop services in reverse dependency order.
 
-        Order: acceptors → processors → writers → stores.
+        Order: dashboard → acceptors → processors → writers → stores.
         ConsolidationScheduler must stop before DatabaseManager
         to prevent writes to a closed pool (P28).
         """
+        # 0. Stop dashboard (stop accepting HTTP/WS)
+        await self._stop_dashboard()
+
         from sovyx.brain.consolidation import ConsolidationScheduler
         from sovyx.bridge.manager import BridgeManager
         from sovyx.cognitive.gate import CogLoopGate

--- a/tests/dashboard/test_lifecycle.py
+++ b/tests/dashboard/test_lifecycle.py
@@ -1,0 +1,122 @@
+"""Tests for dashboard lifecycle integration with Engine."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sovyx.dashboard.server import DashboardServer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clean_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("test-token")
+    monkeypatch.setattr("sovyx.dashboard.server.TOKEN_FILE", token_file)
+
+
+class TestDashboardServer:
+    """Test DashboardServer start/stop lifecycle."""
+
+    @pytest.mark.asyncio()
+    async def test_start_creates_app(self) -> None:
+        server = DashboardServer()
+        mock_uvi_server = MagicMock()
+        mock_uvi_server.serve = AsyncMock()
+
+        with (
+            patch("uvicorn.Config") as mock_config,
+            patch("uvicorn.Server", return_value=mock_uvi_server),
+        ):
+            mock_config.return_value = MagicMock()
+            await server.start()
+
+            assert server.app is not None
+            assert server.ws_manager is not None
+
+    @pytest.mark.asyncio()
+    async def test_start_with_custom_config(self) -> None:
+        from sovyx.engine.config import APIConfig
+
+        config = APIConfig(host="0.0.0.0", port=9999)
+        server = DashboardServer(config=config)
+        mock_uvi_server = MagicMock()
+        mock_uvi_server.serve = AsyncMock()
+
+        with (
+            patch("uvicorn.Config") as mock_config,
+            patch("uvicorn.Server", return_value=mock_uvi_server),
+        ):
+            mock_config.return_value = MagicMock()
+            await server.start()
+
+            call_kwargs = mock_config.call_args
+            assert call_kwargs.kwargs["host"] == "0.0.0.0"
+            assert call_kwargs.kwargs["port"] == 9999
+
+    @pytest.mark.asyncio()
+    async def test_stop_sets_should_exit(self) -> None:
+        server = DashboardServer()
+        mock_uvi_server = MagicMock()
+        server._server = mock_uvi_server
+
+        await server.stop()
+
+        assert mock_uvi_server.should_exit is True
+
+    @pytest.mark.asyncio()
+    async def test_stop_noop_when_not_started(self) -> None:
+        server = DashboardServer()
+        # Should not raise
+        await server.stop()
+
+    @pytest.mark.asyncio()
+    async def test_ws_manager_accessible_after_start(self) -> None:
+        from sovyx.dashboard.server import ConnectionManager
+
+        server = DashboardServer()
+        mock_uvi_server = MagicMock()
+        mock_uvi_server.serve = AsyncMock()
+
+        with (
+            patch("uvicorn.Config", return_value=MagicMock()),
+            patch("uvicorn.Server", return_value=mock_uvi_server),
+        ):
+            await server.start()
+            assert isinstance(server.ws_manager, ConnectionManager)
+
+
+class TestDashboardCLI:
+    """Test 'sovyx dashboard' CLI command."""
+
+    def test_dashboard_info(self) -> None:
+        from typer.testing import CliRunner
+
+        from sovyx.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["dashboard"])
+        assert result.exit_code == 0
+        assert "Sovyx Dashboard" in result.output
+        assert "7777" in result.output
+
+    def test_dashboard_with_token_flag(self, tmp_path: Path) -> None:
+        from typer.testing import CliRunner
+
+        from sovyx.cli.main import app
+
+        # Write a known token
+        token_file = tmp_path / "token"
+        token_file.write_text("my-test-token-123")
+
+        runner = CliRunner()
+        with patch("sovyx.cli.commands.dashboard.TOKEN_FILE", token_file):
+            result = runner.invoke(app, ["dashboard", "--token"])
+
+        assert result.exit_code == 0
+        assert "my-test-token-123" in result.output


### PR DESCRIPTION
## DASH-01: Server Lifecycle Integration

### What
- **Lifecycle integration**: DashboardServer starts after services, stops first during shutdown
- **Registry**: DashboardServer registered for ws_manager access by other services
- **APIConfig.enabled**: respects flag to skip dashboard if disabled
- **CLI command**: `sovyx dashboard` shows URL, `--token` reveals auth token

### Files
- `src/sovyx/engine/lifecycle.py` — _start_dashboard() / _stop_dashboard()
- `src/sovyx/cli/commands/dashboard.py` — new CLI subcommand
- `src/sovyx/cli/main.py` — register dashboard_app

### Tests (7 new, 54 total)
- DashboardServer start/stop/config lifecycle
- ws_manager accessibility after start
- CLI info display + token reveal

### Quality
- `mypy --strict` ✅ | `ruff` ✅ | `pytest` 54/54 ✅

DASH-01 of SOVYX-DASH-DESIGN-MISSION