### PR TITLE
feat(dashboard): DASH-06 brain graph route

### DIFF
--- a/src/sovyx/dashboard/brain.py
+++ b/src/sovyx/dashboard/brain.py
@@ -1,0 +1,126 @@
+"""Dashboard brain graph — read-only queries for concept graph visualization.
+
+Returns nodes (concepts) and links (relations) in a format compatible
+with react-force-graph-2d: {nodes: [{id, name, ...}], links: [{source, target, ...}]}.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from sovyx.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from sovyx.engine.registry import ServiceRegistry
+
+logger = get_logger(__name__)
+
+
+async def get_brain_graph(
+    registry: ServiceRegistry,
+    *,
+    limit: int = 200,
+) -> dict[str, list[dict[str, Any]]]:
+    """Build a graph of concepts and relations for visualization.
+
+    Returns:
+        {"nodes": [...], "links": [...]} where:
+        - nodes: {id, name, category, importance, confidence, access_count}
+        - links: {source, target, relation_type, weight}
+    """
+    nodes = await _get_concepts(registry, limit=limit)
+    node_ids = {n["id"] for n in nodes}
+
+    links = await _get_relations(registry, node_ids)
+
+    return {"nodes": nodes, "links": links}
+
+
+async def _get_concepts(
+    registry: ServiceRegistry,
+    *,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    """Get top concepts ordered by importance + access_count."""
+    try:
+        from sovyx.brain.concept_repo import ConceptRepository
+        from sovyx.engine.types import MindId
+
+        if not registry.is_registered(ConceptRepository):
+            return []
+
+        repo = await registry.resolve(ConceptRepository)
+        mind_id = MindId(await _get_active_mind_id(registry))
+        concepts = await repo.get_by_mind(mind_id, limit=limit, offset=0)
+
+        return [
+            {
+                "id": str(c.id),
+                "name": c.name,
+                "category": c.category.value,
+                "importance": round(c.importance, 3),
+                "confidence": round(c.confidence, 3),
+                "access_count": c.access_count,
+            }
+            for c in concepts
+        ]
+    except Exception:  # noqa: BLE001
+        logger.debug("brain_graph_concepts_failed")
+        return []
+
+
+async def _get_relations(
+    registry: ServiceRegistry,
+    node_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Get relations between the given concept IDs."""
+    try:
+        from sovyx.brain.relation_repo import RelationRepository
+
+        if not registry.is_registered(RelationRepository):
+            return []
+
+        repo = await registry.resolve(RelationRepository)
+
+        # Get relations for all concepts in the set
+        from sovyx.engine.types import ConceptId
+
+        all_links: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        for nid in node_ids:
+            relations = await repo.get_relations_for(ConceptId(nid))
+            for r in relations:
+                # Only include links where both endpoints are in our node set
+                src = str(r.source_id)
+                tgt = str(r.target_id)
+                if src in node_ids and tgt in node_ids:
+                    edge_key = f"{min(src, tgt)}:{max(src, tgt)}"
+                    if edge_key not in seen:
+                        seen.add(edge_key)
+                        all_links.append({
+                            "source": src,
+                            "target": tgt,
+                            "relation_type": r.relation_type.value,
+                            "weight": round(r.weight, 3),
+                        })
+
+        return all_links
+    except Exception:  # noqa: BLE001
+        logger.debug("brain_graph_relations_failed")
+        return []
+
+
+async def _get_active_mind_id(registry: ServiceRegistry) -> str:
+    """Get active mind ID."""
+    try:
+        from sovyx.engine.bootstrap import MindManager
+
+        if registry.is_registered(MindManager):
+            manager = await registry.resolve(MindManager)
+            minds = manager.get_active_minds()
+            if minds:
+                return minds[0]
+    except Exception:  # noqa: BLE001
+        pass
+    return "default"

--- a/src/sovyx/dashboard/server.py
+++ b/src/sovyx/dashboard/server.py
@@ -280,10 +280,15 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
         return JSONResponse({"conversation_id": conversation_id, "messages": []})
 
     @app.get("/api/brain/graph", dependencies=[Depends(verify_token)])
-    async def get_brain_graph() -> JSONResponse:
-        """Brain knowledge graph (nodes + edges)."""
-        # Placeholder — DASH-07
-        return JSONResponse({"nodes": [], "edges": []})
+    async def get_brain_graph(limit: int = 200) -> JSONResponse:
+        """Brain knowledge graph (nodes + links for react-force-graph-2d)."""
+        registry = getattr(app.state, "registry", None)
+        if registry is not None:
+            from sovyx.dashboard.brain import get_brain_graph as _get_graph
+
+            graph = await _get_graph(registry, limit=limit)
+            return JSONResponse(graph)
+        return JSONResponse({"nodes": [], "links": []})
 
     @app.get("/api/logs", dependencies=[Depends(verify_token)])
     async def get_logs(

--- a/tests/dashboard/test_brain.py
+++ b/tests/dashboard/test_brain.py
@@ -1,0 +1,160 @@
+"""Tests for sovyx.dashboard.brain — brain graph queries."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sovyx.dashboard.brain import get_brain_graph
+
+
+def _mock_concept(
+    cid: str, name: str, category: str = "fact", importance: float = 0.5,
+) -> MagicMock:
+    c = MagicMock()
+    c.id = cid
+    c.name = name
+    c.category = MagicMock(value=category)
+    c.importance = importance
+    c.confidence = 0.7
+    c.access_count = 3
+    return c
+
+
+def _mock_relation(src: str, tgt: str, weight: float = 0.5) -> MagicMock:
+    r = MagicMock()
+    r.source_id = src
+    r.target_id = tgt
+    r.relation_type = MagicMock(value="related_to")
+    r.weight = weight
+    return r
+
+
+class TestGetBrainGraph:
+    @pytest.mark.asyncio()
+    async def test_returns_nodes_and_links(self) -> None:
+        concepts = [
+            _mock_concept("c1", "Python"),
+            _mock_concept("c2", "FastAPI"),
+            _mock_concept("c3", "SQLite"),
+        ]
+        relations_c1 = [_mock_relation("c1", "c2", 0.8)]
+        relations_c2 = [_mock_relation("c2", "c3", 0.6)]
+        relations_c3: list[MagicMock] = []
+
+        concept_repo = AsyncMock()
+        concept_repo.get_by_mind = AsyncMock(return_value=concepts)
+
+        relation_repo = AsyncMock()
+
+        async def get_relations_for(cid: str) -> list[MagicMock]:
+            return {"c1": relations_c1, "c2": relations_c2, "c3": relations_c3}.get(str(cid), [])
+
+        relation_repo.get_relations_for = AsyncMock(side_effect=get_relations_for)
+
+        registry = MagicMock()
+
+        def is_registered(cls: type) -> bool:
+            from sovyx.brain.concept_repo import ConceptRepository
+            from sovyx.brain.relation_repo import RelationRepository
+
+            return cls in (ConceptRepository, RelationRepository)
+
+        registry.is_registered.side_effect = is_registered
+
+        async def resolve(cls: type) -> AsyncMock:
+            from sovyx.brain.concept_repo import ConceptRepository
+            from sovyx.brain.relation_repo import RelationRepository
+
+            if cls is ConceptRepository:
+                return concept_repo
+            if cls is RelationRepository:
+                return relation_repo
+            msg = f"Unknown: {cls}"
+            raise ValueError(msg)
+
+        registry.resolve = AsyncMock(side_effect=resolve)
+
+        with patch(
+            "sovyx.dashboard.brain._get_active_mind_id",
+            new_callable=AsyncMock,
+            return_value="mind-1",
+        ):
+            result = await get_brain_graph(registry, limit=100)
+
+        assert len(result["nodes"]) == 3
+        assert result["nodes"][0]["name"] == "Python"
+        assert result["nodes"][0]["category"] == "fact"
+
+        assert len(result["links"]) == 2
+        sources = {link["source"] for link in result["links"]}
+        targets = {link["target"] for link in result["links"]}
+        assert "c1" in sources
+        assert "c2" in sources or "c2" in targets
+
+    @pytest.mark.asyncio()
+    async def test_empty_when_no_repos(self) -> None:
+        registry = MagicMock()
+        registry.is_registered.return_value = False
+
+        result = await get_brain_graph(registry)
+
+        assert result["nodes"] == []
+        assert result["links"] == []
+
+    @pytest.mark.asyncio()
+    async def test_survives_repo_error(self) -> None:
+        registry = MagicMock()
+        registry.is_registered.return_value = True
+        registry.resolve = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await get_brain_graph(registry)
+        assert result["nodes"] == []
+        assert result["links"] == []
+
+    @pytest.mark.asyncio()
+    async def test_deduplicates_edges(self) -> None:
+        """Same edge from both directions should appear only once."""
+        concepts = [
+            _mock_concept("c1", "A"),
+            _mock_concept("c2", "B"),
+        ]
+        # Both c1 and c2 report the same relation
+        rel = _mock_relation("c1", "c2", 0.8)
+
+        concept_repo = AsyncMock()
+        concept_repo.get_by_mind = AsyncMock(return_value=concepts)
+
+        relation_repo = AsyncMock()
+        relation_repo.get_relations_for = AsyncMock(return_value=[rel])
+
+        registry = MagicMock()
+
+        def is_registered(cls: type) -> bool:
+            from sovyx.brain.concept_repo import ConceptRepository
+            from sovyx.brain.relation_repo import RelationRepository
+
+            return cls in (ConceptRepository, RelationRepository)
+
+        registry.is_registered.side_effect = is_registered
+
+        async def resolve(cls: type) -> AsyncMock:
+            from sovyx.brain.concept_repo import ConceptRepository
+
+            if cls is ConceptRepository:
+                return concept_repo
+            return relation_repo  # RelationRepository
+
+        registry.resolve = AsyncMock(side_effect=resolve)
+
+        with patch(
+            "sovyx.dashboard.brain._get_active_mind_id",
+            new_callable=AsyncMock,
+            return_value="mind-1",
+        ):
+            result = await get_brain_graph(registry, limit=100)
+
+        # Should deduplicate: c1→c2 seen from both c1 and c2 traversal
+        assert len(result["links"]) == 1
+        assert result["links"][0]["weight"] == 0.8

--- a/tests/dashboard/test_server.py
+++ b/tests/dashboard/test_server.py
@@ -152,7 +152,7 @@ class TestAPIRoutes:
         assert resp.status_code == 200
         data = resp.json()
         assert "nodes" in data
-        assert "edges" in data
+        assert "links" in data
 
     def test_logs(
         self, client: TestClient, auth_headers: dict[str, str]


### PR DESCRIPTION
## DASH-06: Brain Graph API

### Route
`GET /api/brain/graph?limit=200`

### Response Format (react-force-graph-2d compatible)
```json
{
  "nodes": [{"id", "name", "category", "importance", "confidence", "access_count"}],
  "links": [{"source", "target", "relation_type", "weight"}]
}
```

### Implementation
- `ConceptRepository.get_by_mind()` for concepts
- `RelationRepository.get_relations_for()` for edges
- Edge deduplication (both traversal directions → 1 link)
- Filters links to only include in-set endpoints

### Tests (4 new, 76 total)
`mypy --strict` ✅ | `ruff` ✅ | `pytest` 76/76 ✅

DASH-06 of SOVYX-DASH-DESIGN-MISSION