### PR TITLE
feat(dashboard): DASH-07 log query route with filters

### DIFF
--- a/src/sovyx/dashboard/logs.py
+++ b/src/sovyx/dashboard/logs.py
@@ -1,0 +1,130 @@
+"""Dashboard log queries — read structured JSON log files.
+
+Reads the RotatingFileHandler JSON log file and returns parsed entries.
+Supports filtering by level, module, and text search.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+from sovyx.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = get_logger(__name__)
+
+
+def query_logs(
+    log_file: Path | None,
+    *,
+    level: str | None = None,
+    module: str | None = None,
+    search: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Query structured JSON log file with filters.
+
+    Reads from the end of file (most recent first).
+    Returns up to `limit` matching entries.
+
+    Args:
+        log_file: Path to JSON log file. Returns [] if None or missing.
+        level: Filter by log level (DEBUG, INFO, WARNING, ERROR).
+        module: Filter by logger name (prefix match).
+        search: Full-text search in event/message field.
+        limit: Maximum entries to return.
+
+    Returns:
+        List of log entries (most recent first).
+    """
+    if log_file is None or not log_file.exists():
+        return []
+
+    try:
+        return _read_and_filter(
+            log_file, level=level, module=module, search=search, limit=limit,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("query_logs_failed", log_file=str(log_file))
+        return []
+
+
+def _read_and_filter(
+    log_file: Path,
+    *,
+    level: str | None,
+    module: str | None,
+    search: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Read log file lines and apply filters."""
+    results: deque[dict[str, Any]] = deque(maxlen=limit)
+
+    lines = _tail_lines(log_file, max_lines=limit * 10)
+
+    for line in reversed(lines):
+        if len(results) >= limit:
+            break
+
+        entry = _parse_line(line)
+        if entry is None:
+            continue
+
+        if not _matches_filters(entry, level=level, module=module, search=search):
+            continue
+
+        results.append(entry)
+
+    return list(results)
+
+
+def _tail_lines(path: Path, max_lines: int = 1000) -> list[str]:
+    """Read last N lines from a file efficiently."""
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as f:
+            return list(deque(f, maxlen=max_lines))
+    except OSError:
+        return []
+
+
+def _parse_line(line: str) -> dict[str, Any] | None:
+    """Parse a single JSON log line."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        parsed: dict[str, Any] = json.loads(line)
+        return parsed
+    except json.JSONDecodeError:
+        return None
+
+
+def _matches_filters(
+    entry: dict[str, Any],
+    *,
+    level: str | None,
+    module: str | None,
+    search: str | None,
+) -> bool:
+    """Check if a log entry matches all given filters."""
+    if level is not None:
+        entry_level = entry.get("level", entry.get("severity", "")).upper()
+        if entry_level != level.upper():
+            return False
+
+    if module is not None:
+        entry_logger = entry.get("logger", entry.get("module", ""))
+        if not str(entry_logger).startswith(module):
+            return False
+
+    if search is not None:
+        search_lower = search.lower()
+        event = str(entry.get("event", entry.get("message", ""))).lower()
+        if search_lower not in event and search_lower not in json.dumps(entry).lower():
+            return False
+
+    return True

--- a/src/sovyx/dashboard/server.py
+++ b/src/sovyx/dashboard/server.py
@@ -294,11 +294,17 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
     async def get_logs(
         level: str | None = None,
         module: str | None = None,
+        search: str | None = None,
         limit: int = 100,
     ) -> JSONResponse:
-        """Query structured logs."""
-        # Placeholder — DASH-08
-        return JSONResponse({"entries": []})
+        """Query structured JSON logs with filters."""
+        from sovyx.dashboard.logs import query_logs
+
+        log_file = getattr(app.state, "log_file", None)
+        entries = query_logs(
+            log_file, level=level, module=module, search=search, limit=limit,
+        )
+        return JSONResponse({"entries": entries})
 
     @app.get("/api/settings", dependencies=[Depends(verify_token)])
     async def get_settings() -> JSONResponse:
@@ -434,6 +440,16 @@ class DashboardServer:
 
             self._app.state.status_collector = StatusCollector(self._registry)
             self._app.state.registry = self._registry
+
+        # Wire log file path for log queries
+        if self._config is not None:
+            from sovyx.engine.config import EngineConfig
+
+            try:
+                engine_config = EngineConfig()
+                self._app.state.log_file = engine_config.log.log_file
+            except Exception:  # noqa: BLE001
+                pass
 
         host = self._config.host if self._config else "127.0.0.1"
         port = self._config.port if self._config else 7777

--- a/tests/dashboard/test_logs.py
+++ b/tests/dashboard/test_logs.py
@@ -1,0 +1,106 @@
+"""Tests for sovyx.dashboard.logs — log file query module."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from sovyx.dashboard.logs import query_logs
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _entry(event: str, level: str, logger: str, ts: str) -> dict[str, str]:
+    return {"event": event, "level": level, "logger": logger, "ts": ts}
+
+
+@pytest.fixture()
+def log_file(tmp_path: Path) -> Path:
+    """Create a temp JSON log file with sample entries."""
+    entries = [
+        _entry("engine_started", "info", "sovyx.engine", "2026-04-04T10:00:00"),
+        _entry("message_received", "debug", "sovyx.bridge", "2026-04-04T10:00:01"),
+        _entry("llm_call", "info", "sovyx.cognitive", "2026-04-04T10:00:02"),
+        _entry("db_error", "error", "sovyx.persistence", "2026-04-04T10:00:03"),
+        _entry("concept_created", "info", "sovyx.brain.service", "2026-04-04T10:00:04"),
+    ]
+    f = tmp_path / "sovyx.log"
+    f.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    return f
+
+
+class TestQueryLogs:
+    def test_returns_all_entries(self, log_file: Path) -> None:
+        result = query_logs(log_file, limit=100)
+        assert len(result) == 5
+        # Most recent first
+        assert result[0]["event"] == "concept_created"
+        assert result[-1]["event"] == "engine_started"
+
+    def test_filter_by_level(self, log_file: Path) -> None:
+        result = query_logs(log_file, level="error")
+        assert len(result) == 1
+        assert result[0]["event"] == "db_error"
+
+    def test_filter_by_level_case_insensitive(self, log_file: Path) -> None:
+        result = query_logs(log_file, level="INFO")
+        assert len(result) == 3
+
+    def test_filter_by_module(self, log_file: Path) -> None:
+        result = query_logs(log_file, module="sovyx.brain")
+        assert len(result) == 1
+        assert result[0]["event"] == "concept_created"
+
+    def test_filter_by_module_prefix(self, log_file: Path) -> None:
+        result = query_logs(log_file, module="sovyx")
+        assert len(result) == 5
+
+    def test_filter_by_search(self, log_file: Path) -> None:
+        result = query_logs(log_file, search="llm")
+        assert len(result) == 1
+        assert result[0]["event"] == "llm_call"
+
+    def test_combined_filters(self, log_file: Path) -> None:
+        result = query_logs(log_file, level="info", module="sovyx.brain")
+        assert len(result) == 1
+
+    def test_limit(self, log_file: Path) -> None:
+        result = query_logs(log_file, limit=2)
+        assert len(result) == 2
+        assert result[0]["event"] == "concept_created"
+
+    def test_none_log_file(self) -> None:
+        result = query_logs(None)
+        assert result == []
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        result = query_logs(tmp_path / "nonexistent.log")
+        assert result == []
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.log"
+        f.write_text("")
+        result = query_logs(f)
+        assert result == []
+
+    def test_malformed_lines_skipped(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.log"
+        f.write_text(
+            'not json\n'
+            '{"event": "good", "level": "info", "logger": "test"}\n'
+            '{broken\n'
+        )
+        result = query_logs(f)
+        assert len(result) == 1
+        assert result[0]["event"] == "good"
+
+    def test_search_in_full_entry(self, tmp_path: Path) -> None:
+        """Search matches keys/values beyond event field."""
+        f = tmp_path / "meta.log"
+        content = json.dumps({"event": "call", "level": "info", "model": "gpt-4o"})
+        f.write_text(content + "\n")
+        result = query_logs(f, search="gpt-4o")
+        assert len(result) == 1


### PR DESCRIPTION
## DASH-07: Log Query API

### Route
`GET /api/logs?level=INFO&module=sovyx.brain&search=error&limit=100`

### Filters
- **level**: exact match (case-insensitive)
- **module**: prefix match on logger name
- **search**: full-text in event field + full JSON entry
- **limit**: max entries (default 100)

### Implementation
- Reads RotatingFileHandler JSON log file
- Most recent entries first (reversed)
- Skips malformed JSON lines
- `_tail_lines()`: deque-based efficient reader

### Tests (13 new, 89 total)
`mypy --strict` ✅ | `ruff` ✅ | `pytest` 89/89 ✅

DASH-07 of SOVYX-DASH-DESIGN-MISSION