### PR TITLE
feat(dashboard): DASH-09 WebSocket event bridge for real-time updates

### DIFF
--- a/src/sovyx/dashboard/events.py
+++ b/src/sovyx/dashboard/events.py
@@ -1,0 +1,162 @@
+"""Dashboard WebSocket event bridge.
+
+Subscribes to Engine events via EventBus and broadcasts them to
+connected WebSocket clients via ConnectionManager.
+
+Event types are mapped to dashboard-friendly JSON payloads.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from sovyx.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from sovyx.dashboard.server import ConnectionManager
+    from sovyx.engine.events import Event, EventBus
+
+logger = get_logger(__name__)
+
+
+class DashboardEventBridge:
+    """Bridge between Engine EventBus and WebSocket connections.
+
+    Subscribes to key events and broadcasts JSON payloads to all
+    connected dashboard clients.
+    """
+
+    def __init__(self, ws_manager: ConnectionManager, event_bus: EventBus) -> None:
+        self._ws = ws_manager
+        self._bus = event_bus
+        self._subscribed = False
+
+    def subscribe_all(self) -> None:
+        """Subscribe to all dashboard-relevant events."""
+        if self._subscribed:
+            return
+
+        from sovyx.engine.events import (
+            ChannelConnected,
+            ChannelDisconnected,
+            ConceptCreated,
+            ConsolidationCompleted,
+            EngineStarted,
+            EngineStopping,
+            EpisodeEncoded,
+            PerceptionReceived,
+            ResponseSent,
+            ServiceHealthChanged,
+            ThinkCompleted,
+        )
+
+        event_types = [
+            EngineStarted,
+            EngineStopping,
+            ServiceHealthChanged,
+            PerceptionReceived,
+            ThinkCompleted,
+            ResponseSent,
+            ConceptCreated,
+            EpisodeEncoded,
+            ConsolidationCompleted,
+            ChannelConnected,
+            ChannelDisconnected,
+        ]
+
+        for etype in event_types:
+            self._bus.subscribe(etype, self._handle_event)
+
+        self._subscribed = True
+        logger.debug("dashboard_events_subscribed", count=len(event_types))
+
+    async def _handle_event(self, event: Event) -> None:
+        """Convert Engine event to JSON and broadcast."""
+        if self._ws.active_count == 0:
+            return  # No clients connected, skip serialization
+
+        payload = _serialize_event(event)
+        await self._ws.broadcast(payload)
+
+
+def _serialize_event(event: Event) -> dict[str, Any]:
+    """Convert an Engine event to a dashboard-friendly JSON payload."""
+    from sovyx.engine.events import (
+        ChannelConnected,
+        ChannelDisconnected,
+        ConceptCreated,
+        ConsolidationCompleted,
+        EngineStarted,
+        EngineStopping,
+        EpisodeEncoded,
+        PerceptionReceived,
+        ResponseSent,
+        ServiceHealthChanged,
+        ThinkCompleted,
+    )
+
+    base: dict[str, Any] = {
+        "type": type(event).__name__,
+        "timestamp": event.timestamp.isoformat() if event.timestamp else time.time(),
+        "correlation_id": event.correlation_id,
+    }
+
+    if isinstance(event, EngineStarted):
+        base["data"] = {}
+    elif isinstance(event, EngineStopping):
+        base["data"] = {"reason": event.reason}
+    elif isinstance(event, ServiceHealthChanged):
+        base["data"] = {
+            "service": event.service,
+            "status": event.status,
+        }
+    elif isinstance(event, PerceptionReceived):
+        base["data"] = {
+            "source": event.source,
+            "person_id": event.person_id,
+        }
+    elif isinstance(event, ThinkCompleted):
+        base["data"] = {
+            "tokens_in": event.tokens_in,
+            "tokens_out": event.tokens_out,
+            "model": event.model,
+            "cost_usd": round(event.cost_usd, 6),
+            "latency_ms": event.latency_ms,
+        }
+    elif isinstance(event, ResponseSent):
+        base["data"] = {
+            "channel": event.channel,
+            "latency_ms": event.latency_ms,
+        }
+    elif isinstance(event, ConceptCreated):
+        base["data"] = {
+            "concept_id": event.concept_id,
+            "title": event.title,
+            "source": event.source,
+        }
+    elif isinstance(event, EpisodeEncoded):
+        base["data"] = {
+            "episode_id": event.episode_id,
+            "importance": event.importance,
+        }
+    elif isinstance(event, ConsolidationCompleted):
+        base["data"] = {
+            "merged": event.merged,
+            "pruned": event.pruned,
+            "strengthened": event.strengthened,
+            "duration_s": round(event.duration_s, 2),
+        }
+    elif isinstance(event, ChannelConnected):
+        base["data"] = {
+            "channel_type": event.channel_type,
+        }
+    elif isinstance(event, ChannelDisconnected):
+        base["data"] = {
+            "channel_type": event.channel_type,
+            "reason": event.reason,
+        }
+    else:
+        base["data"] = {}
+
+    return base

--- a/src/sovyx/engine/lifecycle.py
+++ b/src/sovyx/engine/lifecycle.py
@@ -200,6 +200,13 @@ class LifecycleManager:
         await server.start()
         self._registry.register_instance(DashboardServer, server)
 
+        # Wire WebSocket event bridge
+        if server.ws_manager is not None:
+            from sovyx.dashboard.events import DashboardEventBridge
+
+            bridge = DashboardEventBridge(server.ws_manager, self._events)
+            bridge.subscribe_all()
+
     async def _stop_dashboard(self) -> None:
         """Stop the dashboard server if running."""
         from sovyx.dashboard.server import DashboardServer

--- a/tests/dashboard/test_events.py
+++ b/tests/dashboard/test_events.py
@@ -1,0 +1,143 @@
+"""Tests for sovyx.dashboard.events — WebSocket event bridge."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+import pytest
+
+from sovyx.dashboard.events import DashboardEventBridge, _serialize_event
+from sovyx.engine.events import (
+    ChannelConnected,
+    ChannelDisconnected,
+    ConceptCreated,
+    ConsolidationCompleted,
+    EngineStarted,
+    EngineStopping,
+    EpisodeEncoded,
+    EventBus,
+    PerceptionReceived,
+    ResponseSent,
+    ServiceHealthChanged,
+    ThinkCompleted,
+)
+
+
+class TestSerializeEvent:
+    def test_engine_started(self) -> None:
+        event = EngineStarted()
+        result = _serialize_event(event)
+        assert result["type"] == "EngineStarted"
+        assert "timestamp" in result
+        assert result["data"] == {}
+
+    def test_engine_stopping(self) -> None:
+        result = _serialize_event(EngineStopping(reason="shutdown"))
+        assert result["data"]["reason"] == "shutdown"
+
+    def test_service_health_changed(self) -> None:
+        result = _serialize_event(ServiceHealthChanged(service="Database", status="green"))
+        assert result["data"]["service"] == "Database"
+        assert result["data"]["status"] == "green"
+
+    def test_perception_received(self) -> None:
+        result = _serialize_event(PerceptionReceived(source="telegram", person_id="p1"))
+        assert result["data"]["source"] == "telegram"
+        assert result["data"]["person_id"] == "p1"
+
+    def test_think_completed(self) -> None:
+        event = ThinkCompleted(
+            tokens_in=100, tokens_out=50, model="gpt-4o",
+            cost_usd=0.005, latency_ms=1200,
+        )
+        result = _serialize_event(event)
+        assert result["data"]["tokens_in"] == 100
+        assert result["data"]["tokens_out"] == 50
+        assert result["data"]["model"] == "gpt-4o"
+        assert result["data"]["cost_usd"] == 0.005
+        assert result["data"]["latency_ms"] == 1200
+
+    def test_response_sent(self) -> None:
+        result = _serialize_event(ResponseSent(channel="telegram", latency_ms=200))
+        assert result["data"]["channel"] == "telegram"
+
+    def test_concept_created(self) -> None:
+        event = ConceptCreated(concept_id="c1", title="Python", source="conversation")
+        result = _serialize_event(event)
+        assert result["data"]["concept_id"] == "c1"
+        assert result["data"]["title"] == "Python"
+
+    def test_episode_encoded(self) -> None:
+        result = _serialize_event(EpisodeEncoded(episode_id="e1", importance=0.8))
+        assert result["data"]["episode_id"] == "e1"
+        assert result["data"]["importance"] == 0.8
+
+    def test_consolidation_completed(self) -> None:
+        result = _serialize_event(
+            ConsolidationCompleted(merged=5, pruned=3, strengthened=10, duration_s=2.567),
+        )
+        assert result["data"]["merged"] == 5
+        assert result["data"]["pruned"] == 3
+        assert result["data"]["duration_s"] == 2.57
+
+    def test_channel_connected(self) -> None:
+        result = _serialize_event(ChannelConnected(channel_type="telegram"))
+        assert result["data"]["channel_type"] == "telegram"
+
+    def test_channel_disconnected(self) -> None:
+        result = _serialize_event(ChannelDisconnected(channel_type="signal", reason="timeout"))
+        assert result["data"]["reason"] == "timeout"
+
+
+class TestDashboardEventBridge:
+    def test_subscribe_all(self) -> None:
+        ws = MagicMock()
+        bus = EventBus()
+        bridge = DashboardEventBridge(ws, bus)
+
+        bridge.subscribe_all()
+
+        # Should have 11 event types subscribed
+        total_handlers = sum(len(h) for h in bus._handlers.values())
+        assert total_handlers == 11
+
+    def test_subscribe_idempotent(self) -> None:
+        ws = MagicMock()
+        bus = EventBus()
+        bridge = DashboardEventBridge(ws, bus)
+
+        bridge.subscribe_all()
+        bridge.subscribe_all()
+
+        total_handlers = sum(len(h) for h in bus._handlers.values())
+        assert total_handlers == 11  # Not 22
+
+    @pytest.mark.asyncio()
+    async def test_handle_event_broadcasts(self) -> None:
+        ws = MagicMock()
+        type(ws).active_count = PropertyMock(return_value=2)
+        ws.broadcast = AsyncMock()
+
+        bus = EventBus()
+        bridge = DashboardEventBridge(ws, bus)
+        bridge.subscribe_all()
+
+        await bus.emit(EngineStarted())
+
+        ws.broadcast.assert_called_once()
+        payload = ws.broadcast.call_args[0][0]
+        assert payload["type"] == "EngineStarted"
+
+    @pytest.mark.asyncio()
+    async def test_skip_broadcast_no_clients(self) -> None:
+        ws = MagicMock()
+        type(ws).active_count = PropertyMock(return_value=0)
+        ws.broadcast = AsyncMock()
+
+        bus = EventBus()
+        bridge = DashboardEventBridge(ws, bus)
+        bridge.subscribe_all()
+
+        await bus.emit(EngineStarted())
+
+        ws.broadcast.assert_not_called()


### PR DESCRIPTION
## DASH-09: Real-Time WebSocket Events

### Architecture
```
Engine Events → EventBus → DashboardEventBridge → ConnectionManager → WS Clients
```

### 11 Event Types Mapped
| Event | Data Fields |
|-------|------------|
| EngineStarted | — |
| EngineStopping | reason |
| ServiceHealthChanged | service, status |
| PerceptionReceived | source, person_id |
| ThinkCompleted | tokens_in/out, model, cost_usd, latency_ms |
| ResponseSent | channel, latency_ms |
| ConceptCreated | concept_id, title, source |
| EpisodeEncoded | episode_id, importance |
| ConsolidationCompleted | merged, pruned, strengthened, duration_s |
| ChannelConnected | channel_type |
| ChannelDisconnected | channel_type, reason |

### Performance
- Skips serialization when no WS clients connected
- Zero overhead when dashboard is open but nobody watching

### Tests (15 new, 115 total)
`mypy --strict` ✅ | `ruff` ✅ | `pytest` 115/115 ✅

DASH-09 of SOVYX-DASH-DESIGN-MISSION