### PR TITLE
fix(dashboard): quality hardening — race condition, N+1, adversarial tests

### DIFF
--- a/src/sovyx/dashboard/brain.py
+++ b/src/sovyx/dashboard/brain.py
@@ -73,42 +73,95 @@ async def _get_relations(
     registry: ServiceRegistry,
     node_ids: set[str],
 ) -> list[dict[str, Any]]:
-    """Get relations between the given concept IDs."""
+    """Get relations between the given concept IDs.
+
+    Uses a single batch SQL query instead of N+1 per-concept queries.
+    """
+    if not node_ids:
+        return []
+
     try:
-        from sovyx.brain.relation_repo import RelationRepository
+        from sovyx.persistence.manager import DatabaseManager
 
-        if not registry.is_registered(RelationRepository):
-            return []
+        if not registry.is_registered(DatabaseManager):
+            # Fallback: try via RelationRepository (slower, N+1)
+            return await _get_relations_via_repo(registry, node_ids)
 
-        repo = await registry.resolve(RelationRepository)
+        db = await registry.resolve(DatabaseManager)
+        mind_id_str = await _get_active_mind_id(registry)
 
-        # Get relations for all concepts in the set
-        from sovyx.engine.types import ConceptId
+        from sovyx.engine.types import MindId
 
-        all_links: list[dict[str, Any]] = []
+        pool = db.get_brain_pool(MindId(mind_id_str))
+
+        # Single query: all relations where BOTH endpoints are in node_ids
+        placeholders = ",".join("?" for _ in node_ids)
+        ids_list = list(node_ids)
+
+        async with pool.read() as conn:
+            cursor = await conn.execute(
+                f"SELECT source_id, target_id, relation_type, weight "  # noqa: S608  # nosec B608
+                f"FROM relations "
+                f"WHERE source_id IN ({placeholders}) "
+                f"AND target_id IN ({placeholders})",
+                ids_list + ids_list,
+            )
+            rows = await cursor.fetchall()
+
         seen: set[str] = set()
+        links: list[dict[str, Any]] = []
 
-        for nid in node_ids:
-            relations = await repo.get_relations_for(ConceptId(nid))
-            for r in relations:
-                # Only include links where both endpoints are in our node set
-                src = str(r.source_id)
-                tgt = str(r.target_id)
-                if src in node_ids and tgt in node_ids:
-                    edge_key = f"{min(src, tgt)}:{max(src, tgt)}"
-                    if edge_key not in seen:
-                        seen.add(edge_key)
-                        all_links.append({
-                            "source": src,
-                            "target": tgt,
-                            "relation_type": r.relation_type.value,
-                            "weight": round(r.weight, 3),
-                        })
+        for row in rows:
+            src, tgt = str(row[0]), str(row[1])
+            edge_key = f"{min(src, tgt)}:{max(src, tgt)}"
+            if edge_key not in seen:
+                seen.add(edge_key)
+                links.append({
+                    "source": src,
+                    "target": tgt,
+                    "relation_type": str(row[2]),
+                    "weight": round(float(row[3]), 3),
+                })
 
-        return all_links
+        return links
     except Exception:  # noqa: BLE001
         logger.debug("brain_graph_relations_failed")
         return []
+
+
+async def _get_relations_via_repo(
+    registry: ServiceRegistry,
+    node_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Fallback: get relations via RelationRepository (N+1, slower)."""
+    from sovyx.brain.relation_repo import RelationRepository
+
+    if not registry.is_registered(RelationRepository):
+        return []
+
+    repo = await registry.resolve(RelationRepository)
+    from sovyx.engine.types import ConceptId
+
+    all_links: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for nid in node_ids:
+        relations = await repo.get_relations_for(ConceptId(nid))
+        for r in relations:
+            src = str(r.source_id)
+            tgt = str(r.target_id)
+            if src in node_ids and tgt in node_ids:
+                edge_key = f"{min(src, tgt)}:{max(src, tgt)}"
+                if edge_key not in seen:
+                    seen.add(edge_key)
+                    all_links.append({
+                        "source": src,
+                        "target": tgt,
+                        "relation_type": r.relation_type.value,
+                        "weight": round(r.weight, 3),
+                    })
+
+    return all_links
 
 
 async def _get_active_mind_id(registry: ServiceRegistry) -> str:
@@ -122,5 +175,5 @@ async def _get_active_mind_id(registry: ServiceRegistry) -> str:
             if minds:
                 return minds[0]
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug("_get_active_mind_id_failed")
     return "default"

--- a/src/sovyx/dashboard/conversations.py
+++ b/src/sovyx/dashboard/conversations.py
@@ -40,7 +40,7 @@ async def _get_conversation_pool(registry: ServiceRegistry) -> DatabasePool | No
 
                 return db.get_conversation_pool(MindId(minds[0]))
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug("_get_conversation_pool_failed")
 
     # Fallback: try system pool for legacy single-db setups
     try:

--- a/src/sovyx/dashboard/logs.py
+++ b/src/sovyx/dashboard/logs.py
@@ -83,10 +83,29 @@ def _read_and_filter(
 
 
 def _tail_lines(path: Path, max_lines: int = 1000) -> list[str]:
-    """Read last N lines from a file efficiently."""
+    """Read last N lines from a file efficiently using seek-from-end.
+
+    For files up to 1MB, reads the whole file (fast enough).
+    For larger files, seeks to the last ~1MB and reads from there.
+    """
     try:
-        with path.open("r", encoding="utf-8", errors="replace") as f:
-            return list(deque(f, maxlen=max_lines))
+        file_size = path.stat().st_size
+        if file_size == 0:
+            return []
+
+        # For small files, just read all
+        max_read = 1024 * 1024  # 1MB
+        with path.open("rb") as f:
+            if file_size > max_read:
+                f.seek(-max_read, 2)  # Seek from end
+                # Skip partial first line
+                f.readline()
+            data = f.read()
+
+        lines = data.decode("utf-8", errors="replace").splitlines()
+        if len(lines) > max_lines:
+            lines = lines[-max_lines:]
+        return lines
     except OSError:
         return []
 

--- a/src/sovyx/dashboard/server.py
+++ b/src/sovyx/dashboard/server.py
@@ -187,7 +187,9 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
         if collector is not None:
             from sovyx.dashboard.status import StatusCollector
 
-            assert isinstance(collector, StatusCollector)
+            if not isinstance(collector, StatusCollector):
+                msg = f"status_collector is {type(collector)}, expected StatusCollector"
+                raise TypeError(msg)
             snapshot = await collector.collect()
             return JSONResponse(snapshot.to_dict())
 
@@ -366,7 +368,7 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
                 if data == "ping":
                     await websocket.send_text("pong")
         except WebSocketDisconnect:
-            pass
+            logger.debug("ws_client_disconnected")
         finally:
             await ws_manager.disconnect(websocket)
 
@@ -459,7 +461,7 @@ class DashboardServer:
                 engine_config = EngineConfig()
                 self._app.state.log_file = engine_config.log.log_file
             except Exception:  # noqa: BLE001
-                pass
+                logger.debug("engine_config_load_failed")
 
         host = self._config.host if self._config else "127.0.0.1"
         port = self._config.port if self._config else 7777

--- a/src/sovyx/dashboard/status.py
+++ b/src/sovyx/dashboard/status.py
@@ -47,34 +47,45 @@ class StatusSnapshot:
         }
 
 
-@dataclass
 class DashboardCounters:
     """Mutable counters updated by instrumented code via increment methods.
 
     These mirror the OTel metrics but are queryable (OTel counters are write-only).
-    Thread-safe via GIL for simple increments.
+    Uses a threading.Lock to make the check-then-reset in _maybe_reset atomic.
     """
 
-    llm_calls: int = 0
-    llm_cost: float = 0.0
-    tokens: int = 0
-    messages_received: int = 0
-    _day_key: str = ""
+    def __init__(self) -> None:
+        import threading
+
+        self._lock = threading.Lock()
+        self.llm_calls: int = 0
+        self.llm_cost: float = 0.0
+        self.tokens: int = 0
+        self.messages_received: int = 0
+        self._day_key: str = ""
 
     def record_llm_call(self, cost: float, tokens: int) -> None:
         """Record an LLM call."""
-        self._maybe_reset()
-        self.llm_calls += 1
-        self.llm_cost += cost
-        self.tokens += tokens
+        with self._lock:
+            self._maybe_reset()
+            self.llm_calls += 1
+            self.llm_cost += cost
+            self.tokens += tokens
 
     def record_message(self) -> None:
         """Record an inbound message."""
-        self._maybe_reset()
-        self.messages_received += 1
+        with self._lock:
+            self._maybe_reset()
+            self.messages_received += 1
+
+    def snapshot(self) -> tuple[int, float, int, int]:
+        """Atomic read of (llm_calls, llm_cost, tokens, messages_received)."""
+        with self._lock:
+            self._maybe_reset()
+            return self.llm_calls, self.llm_cost, self.tokens, self.messages_received
 
     def _maybe_reset(self) -> None:
-        """Reset counters at day boundary."""
+        """Reset counters at day boundary. Must be called under lock."""
         today = time.strftime("%Y-%m-%d")
         if self._day_key != today:
             self.llm_calls = 0
@@ -111,7 +122,7 @@ class StatusCollector:
         mind_name = await self._get_mind_name()
         concepts, episodes = await self._get_memory_stats()
 
-        counters = get_counters()
+        calls, cost, tokens, _msgs = get_counters().snapshot()
 
         return StatusSnapshot(
             version=__version__,
@@ -120,9 +131,9 @@ class StatusCollector:
             active_conversations=await self._get_conversation_count(),
             memory_concepts=concepts,
             memory_episodes=episodes,
-            llm_cost_today=counters.llm_cost,
-            llm_calls_today=counters.llm_calls,
-            tokens_today=counters.tokens,
+            llm_cost_today=cost,
+            llm_calls_today=calls,
+            tokens_today=tokens,
         )
 
     async def _get_mind_name(self) -> str:
@@ -189,5 +200,5 @@ class StatusCollector:
                 if minds:
                     return minds[0]
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug("_get_active_mind_id_failed")
         return "default"

--- a/tests/dashboard/test_adversarial.py
+++ b/tests/dashboard/test_adversarial.py
@@ -1,0 +1,310 @@
+"""Adversarial edge-case tests for dashboard modules.
+
+Tests unusual inputs, boundary conditions, concurrent access,
+large data, malformed content, and error recovery.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from sovyx.dashboard.logs import query_logs
+from sovyx.dashboard.status import DashboardCounters, StatusSnapshot
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ── DashboardCounters Adversarial ──
+
+
+class TestCountersThreadSafety:
+    def test_concurrent_increments(self) -> None:
+        """Multiple threads incrementing should not lose counts."""
+        c = DashboardCounters()
+        n_threads = 10
+        n_increments = 1000
+
+        def worker() -> None:
+            for _ in range(n_increments):
+                c.record_llm_call(cost=0.001, tokens=1)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert c.llm_calls == n_threads * n_increments
+        assert c.tokens == n_threads * n_increments
+        assert abs(c.llm_cost - n_threads * n_increments * 0.001) < 0.01
+
+    def test_concurrent_mixed_operations(self) -> None:
+        """Mixed record_llm_call and record_message from multiple threads."""
+        c = DashboardCounters()
+
+        def llm_worker() -> None:
+            for _ in range(500):
+                c.record_llm_call(cost=0.01, tokens=10)
+
+        def msg_worker() -> None:
+            for _ in range(500):
+                c.record_message()
+
+        threads = [
+            threading.Thread(target=llm_worker),
+            threading.Thread(target=llm_worker),
+            threading.Thread(target=msg_worker),
+            threading.Thread(target=msg_worker),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert c.llm_calls == 1000
+        assert c.messages_received == 1000
+
+    def test_snapshot_atomic(self) -> None:
+        """Snapshot should return consistent values."""
+        c = DashboardCounters()
+        c.record_llm_call(cost=0.05, tokens=500)
+        c.record_llm_call(cost=0.03, tokens=300)
+
+        calls, cost, tokens, msgs = c.snapshot()
+        assert calls == 2
+        assert tokens == 800
+        assert abs(cost - 0.08) < 0.001
+        assert msgs == 0
+
+    def test_day_boundary_under_contention(self) -> None:
+        """Force day boundary during concurrent writes."""
+        c = DashboardCounters()
+        c._day_key = "2020-01-01"  # Force old date
+
+        def worker() -> None:
+            for _ in range(100):
+                c.record_llm_call(cost=0.001, tokens=1)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # After reset + 500 increments, should be exactly 500
+        assert c.llm_calls == 500
+
+
+class TestCountersEdgeCases:
+    def test_zero_cost_and_tokens(self) -> None:
+        c = DashboardCounters()
+        c.record_llm_call(cost=0.0, tokens=0)
+        assert c.llm_calls == 1
+        assert c.llm_cost == 0.0
+        assert c.tokens == 0
+
+    def test_very_large_values(self) -> None:
+        c = DashboardCounters()
+        c.record_llm_call(cost=999999.99, tokens=2**31)
+        assert c.llm_cost == 999999.99
+        assert c.tokens == 2**31
+
+    def test_negative_cost(self) -> None:
+        """Negative cost (refund?) should still work."""
+        c = DashboardCounters()
+        c.record_llm_call(cost=0.10, tokens=100)
+        c.record_llm_call(cost=-0.05, tokens=0)
+        assert abs(c.llm_cost - 0.05) < 0.001
+
+    def test_float_precision(self) -> None:
+        """Many small additions should not lose precision badly."""
+        c = DashboardCounters()
+        for _ in range(10000):
+            c.record_llm_call(cost=0.001, tokens=1)
+        assert abs(c.llm_cost - 10.0) < 0.01  # Allow small float drift
+
+
+# ── StatusSnapshot Adversarial ──
+
+
+class TestSnapshotEdgeCases:
+    def test_zero_uptime(self) -> None:
+        snap = StatusSnapshot(
+            version="0.1.0", uptime_seconds=0.0, mind_name="test",
+            active_conversations=0, memory_concepts=0, memory_episodes=0,
+            llm_cost_today=0.0, llm_calls_today=0, tokens_today=0,
+        )
+        d = snap.to_dict()
+        assert d["uptime_seconds"] == 0.0
+
+    def test_huge_uptime(self) -> None:
+        snap = StatusSnapshot(
+            version="0.1.0", uptime_seconds=31536000.123456,  # 1 year
+            mind_name="test", active_conversations=0, memory_concepts=0,
+            memory_episodes=0, llm_cost_today=0.0, llm_calls_today=0,
+            tokens_today=0,
+        )
+        d = snap.to_dict()
+        assert d["uptime_seconds"] == 31536000.1
+
+    def test_unicode_mind_name(self) -> None:
+        snap = StatusSnapshot(
+            version="0.1.0", uptime_seconds=100, mind_name="Ñyx 🔮 日本語",
+            active_conversations=0, memory_concepts=0, memory_episodes=0,
+            llm_cost_today=0.0, llm_calls_today=0, tokens_today=0,
+        )
+        d = snap.to_dict()
+        assert d["mind_name"] == "Ñyx 🔮 日本語"
+
+    def test_very_small_cost(self) -> None:
+        snap = StatusSnapshot(
+            version="0.1.0", uptime_seconds=100, mind_name="test",
+            active_conversations=0, memory_concepts=0, memory_episodes=0,
+            llm_cost_today=0.00001, llm_calls_today=1, tokens_today=1,
+        )
+        d = snap.to_dict()
+        assert d["llm_cost_today"] == 0.0  # Rounded to 4 decimals
+
+
+# ── Log Query Adversarial ──
+
+
+class TestLogQueryAdversarial:
+    def test_large_file(self, tmp_path: Path) -> None:
+        """10k log lines should not OOM."""
+        f = tmp_path / "big.log"
+        lines = [json.dumps({"event": f"ev-{i}", "level": "info"}) for i in range(10000)]
+        f.write_text("\n".join(lines) + "\n")
+
+        result = query_logs(f, limit=50)
+        assert len(result) == 50
+        assert result[0]["event"] == "ev-9999"  # Most recent first
+
+    def test_unicode_in_logs(self, tmp_path: Path) -> None:
+        f = tmp_path / "unicode.log"
+        entries = [
+            json.dumps({"event": "日本語テスト", "level": "info"}),
+            json.dumps({"event": "emoji 🔮✨", "level": "info"}),
+            json.dumps({"event": "nullbyte\x00test", "level": "info"}),
+        ]
+        f.write_text("\n".join(entries) + "\n")
+
+        result = query_logs(f)
+        assert len(result) == 3
+
+    def test_search_unicode(self, tmp_path: Path) -> None:
+        f = tmp_path / "uni.log"
+        f.write_text(json.dumps({"event": "概念作成 🧠", "level": "info"}) + "\n")
+
+        result = query_logs(f, search="概念")
+        assert len(result) == 1
+
+    def test_binary_garbage_in_log(self, tmp_path: Path) -> None:
+        """Binary data mixed with JSON should not crash."""
+        f = tmp_path / "garbage.log"
+        good = json.dumps({"event": "good", "level": "info"})
+        f.write_bytes(b'\x80\xff\xfe\n' + good.encode() + b'\n' + b'\x00\x01\x02\n')
+
+        result = query_logs(f)
+        assert len(result) == 1
+        assert result[0]["event"] == "good"
+
+    def test_empty_json_objects(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.log"
+        f.write_text("{}\n{}\n{}\n")
+
+        result = query_logs(f)
+        assert len(result) == 3
+
+    def test_nested_json(self, tmp_path: Path) -> None:
+        f = tmp_path / "nested.log"
+        entry = {"event": "complex", "level": "info", "data": {"nested": {"deep": True}}}
+        f.write_text(json.dumps(entry) + "\n")
+
+        result = query_logs(f, search="deep")
+        assert len(result) == 1
+
+    def test_very_long_line(self, tmp_path: Path) -> None:
+        """Single log line with 100KB content should not crash."""
+        f = tmp_path / "long.log"
+        entry = {"event": "x" * 100000, "level": "info"}
+        f.write_text(json.dumps(entry) + "\n")
+
+        result = query_logs(f)
+        assert len(result) == 1
+        assert len(result[0]["event"]) == 100000
+
+    def test_limit_zero(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.log"
+        f.write_text(json.dumps({"event": "test", "level": "info"}) + "\n")
+
+        result = query_logs(f, limit=0)
+        assert result == []
+
+    def test_filter_nonexistent_level(self, tmp_path: Path) -> None:
+        f = tmp_path / "test.log"
+        f.write_text(json.dumps({"event": "test", "level": "info"}) + "\n")
+
+        result = query_logs(f, level="TRACE")
+        assert result == []
+
+    def test_file_deleted_during_read(self, tmp_path: Path) -> None:
+        """File disappearing should return empty, not crash."""
+        f = tmp_path / "ghost.log"
+        result = query_logs(f)
+        assert result == []
+
+
+# ── Brain Graph Adversarial ──
+
+
+class TestBrainGraphAdversarial:
+    @pytest.mark.asyncio()
+    async def test_empty_node_ids(self) -> None:
+        from sovyx.dashboard.brain import _get_relations
+
+        registry = MagicMock()
+        result = await _get_relations(registry, set())
+        assert result == []
+
+    @pytest.mark.asyncio()
+    async def test_graph_with_zero_limit(self) -> None:
+        from sovyx.dashboard.brain import get_brain_graph
+
+        registry = MagicMock()
+        registry.is_registered.return_value = False
+
+        result = await get_brain_graph(registry, limit=0)
+        assert result["nodes"] == []
+        assert result["links"] == []
+
+
+# ── Event Serialization Adversarial ──
+
+
+class TestEventSerializationAdversarial:
+    def test_unknown_event_type(self) -> None:
+        """Unknown event types should serialize with empty data."""
+        from sovyx.dashboard.events import _serialize_event
+        from sovyx.engine.events import Event
+
+        # Create a custom event subclass
+        event = Event()
+        result = _serialize_event(event)
+        assert result["type"] == "Event"
+        assert result["data"] == {}
+
+    def test_event_with_none_timestamp(self) -> None:
+        """Event with None timestamp should use time.time() fallback."""
+        from sovyx.dashboard.events import _serialize_event
+        from sovyx.engine.events import EngineStarted
+
+        event = EngineStarted()
+        result = _serialize_event(event)
+        assert result["timestamp"] is not None


### PR DESCRIPTION
## Quality Hardening PR

### 🔴 Bug Fixes
1. **DashboardCounters race condition**: `threading.Lock` wraps `_maybe_reset()` + increments. Added `snapshot()` for atomic reads.
2. **Brain graph N+1**: Single batch SQL (`WHERE IN`) instead of 200 per-concept queries.
3. **Log reader**: Seek-from-end for files >1MB instead of reading entire file into memory.

### 🟡 Quality Fixes
- Bandit clean: `assert` → `TypeError`, bare `pass` → `logger.debug()`
- All bandit issues resolved (was 6, now 0)

### 🧪 26 Adversarial Tests
- Thread safety (10 threads × 1000 ops), day boundary contention
- 10k log lines, Unicode, binary garbage, 100KB lines
- Edge cases: zero/huge/negative values, float precision

### Metrics
- **141 tests** | `mypy --strict` ✅ | `ruff` ✅ | `bandit` ✅
- **Coverage**: 80% (brain.py/conversations.py DB paths need integration tests)