### PR TITLE
fix(dashboard): quality round 2 — dead code, DRY, param validation

### DIFF
--- a/src/sovyx/dashboard/_shared.py
+++ b/src/sovyx/dashboard/_shared.py
@@ -1,0 +1,35 @@
+"""Shared utilities for dashboard modules.
+
+Contains common logic used across status, brain, and conversations modules
+to avoid DRY violations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sovyx.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from sovyx.engine.registry import ServiceRegistry
+
+logger = get_logger(__name__)
+
+
+async def get_active_mind_id(registry: ServiceRegistry) -> str:
+    """Get the first active mind ID from MindManager.
+
+    Used by status, brain, and conversations modules for mind-scoped queries.
+    Returns "default" if MindManager is unavailable.
+    """
+    try:
+        from sovyx.engine.bootstrap import MindManager
+
+        if registry.is_registered(MindManager):
+            manager = await registry.resolve(MindManager)
+            minds = manager.get_active_minds()
+            if minds:
+                return minds[0]
+    except Exception:  # noqa: BLE001
+        logger.debug("get_active_mind_id_failed")
+    return "default"

--- a/src/sovyx/dashboard/brain.py
+++ b/src/sovyx/dashboard/brain.py
@@ -165,15 +165,7 @@ async def _get_relations_via_repo(
 
 
 async def _get_active_mind_id(registry: ServiceRegistry) -> str:
-    """Get active mind ID."""
-    try:
-        from sovyx.engine.bootstrap import MindManager
+    """Get active mind ID — delegates to shared utility."""
+    from sovyx.dashboard._shared import get_active_mind_id
 
-        if registry.is_registered(MindManager):
-            manager = await registry.resolve(MindManager)
-            minds = manager.get_active_minds()
-            if minds:
-                return minds[0]
-    except Exception:  # noqa: BLE001
-        logger.debug("_get_active_mind_id_failed")
-    return "default"
+    return await get_active_mind_id(registry)

--- a/src/sovyx/dashboard/conversations.py
+++ b/src/sovyx/dashboard/conversations.py
@@ -30,15 +30,11 @@ async def _get_conversation_pool(registry: ServiceRegistry) -> DatabasePool | No
     db = await registry.resolve(DatabaseManager)
     # Conversations are per-mind; use first available mind
     try:
-        from sovyx.engine.bootstrap import MindManager
+        from sovyx.dashboard._shared import get_active_mind_id
+        from sovyx.engine.types import MindId
 
-        if registry.is_registered(MindManager):
-            manager = await registry.resolve(MindManager)
-            minds = manager.get_active_minds()
-            if minds:
-                from sovyx.engine.types import MindId
-
-                return db.get_conversation_pool(MindId(minds[0]))
+        mind_id = await get_active_mind_id(registry)
+        return db.get_conversation_pool(MindId(mind_id))
     except Exception:  # noqa: BLE001
         logger.debug("_get_conversation_pool_failed")
 

--- a/src/sovyx/dashboard/logs.py
+++ b/src/sovyx/dashboard/logs.py
@@ -142,8 +142,16 @@ def _matches_filters(
 
     if search is not None:
         search_lower = search.lower()
+        # Fast path: check event/message field
         event = str(entry.get("event", entry.get("message", ""))).lower()
-        if search_lower not in event and search_lower not in json.dumps(entry).lower():
-            return False
+        if search_lower in event:
+            return True  # Early match — skip other filters below
+        # Medium path: check all string values without serialization
+        for val in entry.values():
+            if isinstance(val, str) and search_lower in val.lower():
+                return True
+        # Slow path: nested dicts/lists need json serialization
+        has_nested = any(isinstance(v, (dict, list)) for v in entry.values())
+        return has_nested and search_lower in json.dumps(entry, default=str).lower()
 
     return True

--- a/src/sovyx/dashboard/server.py
+++ b/src/sovyx/dashboard/server.py
@@ -49,36 +49,6 @@ def _ensure_token() -> str:
     return token
 
 
-# ── Auth Dependency ──
-
-
-def _verify_bearer(authorization: str | None = None) -> str:
-    """Validate Bearer token from Authorization header.
-
-    Returns the token if valid, raises 401 otherwise.
-    """
-    if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=HTTP_401_UNAUTHORIZED,
-            detail="Missing or invalid Authorization header",
-        )
-    token = authorization.removeprefix("Bearer ").strip()
-    if not secrets.compare_digest(token, _server_token):
-        raise HTTPException(
-            status_code=HTTP_401_UNAUTHORIZED,
-            detail="Invalid token",
-        )
-    return token
-
-
-async def require_auth(
-    authorization: str | None = None,  # noqa: ARG001 — injected by FastAPI from header
-) -> None:
-    """FastAPI dependency — validates Bearer token."""
-    # FastAPI extracts the Authorization header automatically via parameter name
-    pass
-
-
 # Will be set during create_app()
 _server_token: str = ""
 
@@ -253,8 +223,8 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
 
     @app.get("/api/conversations", dependencies=[Depends(verify_token)])
     async def get_conversations(
-        limit: int = 50,
-        offset: int = 0,
+        limit: int = Query(default=50, ge=0, le=500),
+        offset: int = Query(default=0, ge=0),
     ) -> JSONResponse:
         """List conversations ordered by most recent activity."""
         registry = getattr(app.state, "registry", None)
@@ -268,7 +238,7 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
     @app.get("/api/conversations/{conversation_id}", dependencies=[Depends(verify_token)])
     async def get_conversation_detail(
         conversation_id: str,
-        limit: int = 100,
+        limit: int = Query(default=100, ge=0, le=1000),
     ) -> JSONResponse:
         """Get messages for a specific conversation."""
         registry = getattr(app.state, "registry", None)
@@ -282,7 +252,7 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
         return JSONResponse({"conversation_id": conversation_id, "messages": []})
 
     @app.get("/api/brain/graph", dependencies=[Depends(verify_token)])
-    async def get_brain_graph(limit: int = 200) -> JSONResponse:
+    async def get_brain_graph(limit: int = Query(default=200, ge=0, le=1000)) -> JSONResponse:
         """Brain knowledge graph (nodes + links for react-force-graph-2d)."""
         registry = getattr(app.state, "registry", None)
         if registry is not None:
@@ -297,7 +267,7 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
         level: str | None = None,
         module: str | None = None,
         search: str | None = None,
-        limit: int = 100,
+        limit: int = Query(default=100, ge=0, le=1000),
     ) -> JSONResponse:
         """Query structured JSON logs with filters."""
         from sovyx.dashboard.logs import query_logs

--- a/src/sovyx/dashboard/status.py
+++ b/src/sovyx/dashboard/status.py
@@ -152,28 +152,27 @@ class StatusCollector:
 
     async def _get_memory_stats(self) -> tuple[int, int]:
         """Get concept and episode counts from brain repositories."""
+        from sovyx.engine.types import MindId
+
         concepts = 0
         episodes = 0
+        mind_id = MindId(await self._get_active_mind_id())
 
         try:
             from sovyx.brain.concept_repo import ConceptRepository
-            from sovyx.engine.types import MindId
 
             if self._registry.is_registered(ConceptRepository):
                 c_repo = await self._registry.resolve(ConceptRepository)
-                mind_id = MindId(await self._get_active_mind_id())
                 concepts = await c_repo.count(mind_id)
         except Exception:  # noqa: BLE001
             logger.debug("status_concepts_failed")
 
         try:
             from sovyx.brain.episode_repo import EpisodeRepository
-            from sovyx.engine.types import MindId as MindId2
 
             if self._registry.is_registered(EpisodeRepository):
                 e_repo = await self._registry.resolve(EpisodeRepository)
-                mind_id2 = MindId2(await self._get_active_mind_id())
-                episodes = await e_repo.count(mind_id2)
+                episodes = await e_repo.count(mind_id)
         except Exception:  # noqa: BLE001
             logger.debug("status_episodes_failed")
 
@@ -191,14 +190,6 @@ class StatusCollector:
 
     async def _get_active_mind_id(self) -> str:
         """Get the first active mind ID for repository queries."""
-        try:
-            from sovyx.engine.bootstrap import MindManager
+        from sovyx.dashboard._shared import get_active_mind_id
 
-            if self._registry.is_registered(MindManager):
-                manager = await self._registry.resolve(MindManager)
-                minds = manager.get_active_minds()
-                if minds:
-                    return minds[0]
-        except Exception:  # noqa: BLE001
-            logger.debug("_get_active_mind_id_failed")
-        return "default"
+        return await get_active_mind_id(self._registry)

--- a/tests/dashboard/test_adversarial.py
+++ b/tests/dashboard/test_adversarial.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi.testclient import TestClient
 
 from sovyx.dashboard.logs import query_logs
 from sovyx.dashboard.status import DashboardCounters, StatusSnapshot
@@ -283,6 +284,50 @@ class TestBrainGraphAdversarial:
         result = await get_brain_graph(registry, limit=0)
         assert result["nodes"] == []
         assert result["links"] == []
+
+
+# ── Query Param Validation ──
+
+
+class TestQueryParamValidation:
+    """Ensure API routes reject invalid query params."""
+
+    @pytest.fixture()
+    def client(self) -> TestClient:
+        from sovyx.dashboard.server import TOKEN_FILE, create_app
+
+        app = create_app()
+        token = TOKEN_FILE.read_text().strip()
+        self._headers = {"Authorization": f"Bearer {token}"}
+        return TestClient(app)
+
+    def test_conversations_negative_limit(self, client: TestClient) -> None:
+        resp = client.get("/api/conversations?limit=-1", headers=self._headers)
+        assert resp.status_code == 422
+
+    def test_conversations_huge_limit(self, client: TestClient) -> None:
+        resp = client.get("/api/conversations?limit=999999", headers=self._headers)
+        assert resp.status_code == 422
+
+    def test_conversations_negative_offset(self, client: TestClient) -> None:
+        resp = client.get("/api/conversations?offset=-5", headers=self._headers)
+        assert resp.status_code == 422
+
+    def test_brain_graph_negative_limit(self, client: TestClient) -> None:
+        resp = client.get("/api/brain/graph?limit=-1", headers=self._headers)
+        assert resp.status_code == 422
+
+    def test_brain_graph_huge_limit(self, client: TestClient) -> None:
+        resp = client.get("/api/brain/graph?limit=5000", headers=self._headers)
+        assert resp.status_code == 422
+
+    def test_logs_negative_limit(self, client: TestClient) -> None:
+        resp = client.get("/api/logs?limit=-1", headers=self._headers)
+        assert resp.status_code == 422
+
+    def test_logs_huge_limit(self, client: TestClient) -> None:
+        resp = client.get("/api/logs?limit=9999", headers=self._headers)
+        assert resp.status_code == 422
 
 
 # ── Event Serialization Adversarial ──


### PR DESCRIPTION
## Quality Round 2

### Issues Found in Deep Code Review
1. **Dead code removed**: `_verify_bearer()` and `require_auth()` never called
2. **DRY**: `_get_active_mind_id` extracted to `_shared.py` (was 3 copies)
3. **Redundant await**: `_get_memory_stats` called mind ID twice → once
4. **Param validation**: `Query(ge=0, le=N)` on all routes
5. **Search perf**: 3-tier strategy (fast→medium→slow)

### Tests (7 new, 148 total)
`mypy --strict` ✅ | `ruff` ✅ | `bandit` ✅ | `pytest` 148/148 ✅