### PR TITLE
fix(dashboard): final polish — UTC, SQLite compat, dead code

### DIFF
--- a/src/sovyx/dashboard/brain.py
+++ b/src/sovyx/dashboard/brain.py
@@ -94,25 +94,33 @@ async def _get_relations(
 
         pool = db.get_brain_pool(MindId(mind_id_str))
 
-        # Single query: all relations where BOTH endpoints are in node_ids
-        placeholders = ",".join("?" for _ in node_ids)
+        # Batch query: relations where source OR target is in node_ids,
+        # then filter in Python to keep only edges where BOTH endpoints are in set.
+        # Chunked to stay within SQLite bind param limits (999 on older versions).
         ids_list = list(node_ids)
+        rows: list[Any] = []
+        chunk_size = 900  # Single IN clause, stays under 999
 
         async with pool.read() as conn:
-            cursor = await conn.execute(
-                f"SELECT source_id, target_id, relation_type, weight "  # noqa: S608  # nosec B608
-                f"FROM relations "
-                f"WHERE source_id IN ({placeholders}) "
-                f"AND target_id IN ({placeholders})",
-                ids_list + ids_list,
-            )
-            rows = await cursor.fetchall()
+            for i in range(0, len(ids_list), chunk_size):
+                chunk = ids_list[i : i + chunk_size]
+                placeholders = ",".join("?" for _ in chunk)
+                cursor = await conn.execute(
+                    f"SELECT source_id, target_id, relation_type, weight "  # noqa: S608  # nosec B608
+                    f"FROM relations "
+                    f"WHERE source_id IN ({placeholders})",
+                    chunk,
+                )
+                rows.extend(await cursor.fetchall())
 
         seen: set[str] = set()
         links: list[dict[str, Any]] = []
 
         for row in rows:
             src, tgt = str(row[0]), str(row[1])
+            # Filter: both endpoints must be in the visible node set
+            if tgt not in node_ids:
+                continue
             edge_key = f"{min(src, tgt)}:{max(src, tgt)}"
             if edge_key not in seen:
                 seen.add(edge_key)

--- a/src/sovyx/dashboard/conversations.py
+++ b/src/sovyx/dashboard/conversations.py
@@ -75,7 +75,7 @@ async def list_conversations(
                 "channel": row[2],
                 "message_count": row[3],
                 "last_message_at": row[4],
-                "status": row[5] if len(row) > 5 else "active",
+                "status": row[5],
             }
             for row in rows
         ]

--- a/src/sovyx/dashboard/events.py
+++ b/src/sovyx/dashboard/events.py
@@ -8,7 +8,6 @@ Event types are mapped to dashboard-friendly JSON payloads.
 
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING, Any
 
 from sovyx.observability.logging import get_logger
@@ -98,7 +97,7 @@ def _serialize_event(event: Event) -> dict[str, Any]:
 
     base: dict[str, Any] = {
         "type": type(event).__name__,
-        "timestamp": event.timestamp.isoformat() if event.timestamp else time.time(),
+        "timestamp": event.timestamp.isoformat(),
         "correlation_id": event.correlation_id,
     }
 

--- a/src/sovyx/dashboard/status.py
+++ b/src/sovyx/dashboard/status.py
@@ -85,8 +85,8 @@ class DashboardCounters:
             return self.llm_calls, self.llm_cost, self.tokens, self.messages_received
 
     def _maybe_reset(self) -> None:
-        """Reset counters at day boundary. Must be called under lock."""
-        today = time.strftime("%Y-%m-%d")
+        """Reset counters at UTC day boundary. Must be called under lock."""
+        today = time.strftime("%Y-%m-%d", time.gmtime())
         if self._day_key != today:
             self.llm_calls = 0
             self.llm_cost = 0.0

--- a/tests/dashboard/test_adversarial.py
+++ b/tests/dashboard/test_adversarial.py
@@ -345,11 +345,12 @@ class TestEventSerializationAdversarial:
         assert result["type"] == "Event"
         assert result["data"] == {}
 
-    def test_event_with_none_timestamp(self) -> None:
-        """Event with None timestamp should use time.time() fallback."""
+    def test_event_timestamp_is_isoformat(self) -> None:
+        """Event timestamp is always an ISO format string."""
         from sovyx.dashboard.events import _serialize_event
         from sovyx.engine.events import EngineStarted
 
         event = EngineStarted()
         result = _serialize_event(event)
-        assert result["timestamp"] is not None
+        assert isinstance(result["timestamp"], str)
+        assert "T" in result["timestamp"]  # ISO 8601


### PR DESCRIPTION
## Final Polish (Review Round 3)

1. **UTC day boundary**: `time.gmtime()` instead of local time
2. **SQLite compat**: chunked IN clause (900 per chunk) for older SQLite
3. **Dead code**: removed unreachable branches in events.py and conversations.py

160 tests | `mypy --strict` ✅ | `ruff` ✅ | `bandit` ✅