### PR TITLE
fix(dashboard): final audit — broadcast lock, path traversal, links cap

### DIFF
--- a/src/sovyx/dashboard/brain.py
+++ b/src/sovyx/dashboard/brain.py
@@ -31,7 +31,9 @@ async def get_brain_graph(
     nodes = await _get_concepts(registry, limit=limit)
     node_ids = {n["id"] for n in nodes}
 
-    links = await _get_relations(registry, node_ids)
+    # Cap links at 3x nodes to keep response size bounded
+    max_links = limit * 3
+    links = await _get_relations(registry, node_ids, max_links=max_links)
 
     return {"nodes": nodes, "links": links}
 
@@ -72,6 +74,7 @@ async def _get_concepts(
 async def _get_relations(
     registry: ServiceRegistry,
     node_ids: set[str],
+    max_links: int = 600,
 ) -> list[dict[str, Any]]:
     """Get relations between the given concept IDs.
 
@@ -117,6 +120,8 @@ async def _get_relations(
         links: list[dict[str, Any]] = []
 
         for row in rows:
+            if len(links) >= max_links:
+                break
             src, tgt = str(row[0]), str(row[1])
             # Filter: both endpoints must be in the visible node set
             if tgt not in node_ids:

--- a/src/sovyx/dashboard/server.py
+++ b/src/sovyx/dashboard/server.py
@@ -76,16 +76,29 @@ class ConnectionManager:
         logger.debug("ws_disconnected", count=len(self._connections))
 
     async def broadcast(self, message: dict[str, Any]) -> None:
-        """Send JSON message to all connected clients."""
+        """Send JSON message to all connected clients.
+
+        Copies the connection list and releases the lock before sending,
+        so a slow client doesn't block other sends or connect/disconnect.
+        """
         async with self._lock:
-            stale: list[WebSocket] = []
-            for ws in self._connections:
-                try:
-                    await ws.send_json(message)
-                except Exception:  # noqa: BLE001
-                    stale.append(ws)
-            for ws in stale:
-                self._connections.remove(ws)
+            snapshot = list(self._connections)
+
+        if not snapshot:
+            return
+
+        stale: list[WebSocket] = []
+        for ws in snapshot:
+            try:
+                await ws.send_json(message)
+            except Exception:  # noqa: BLE001
+                stale.append(ws)
+
+        if stale:
+            async with self._lock:
+                for ws in stale:
+                    if ws in self._connections:
+                        self._connections.remove(ws)
 
     @property
     def active_count(self) -> int:
@@ -352,12 +365,18 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
             name="static-assets",
         )
 
+        _static_root = STATIC_DIR.resolve()
+
         @app.get("/{path:path}")
         async def spa_fallback(path: str) -> FileResponse:
             """SPA fallback — serve index.html for all non-API routes."""
-            # Check if a static file exists
-            file_path = STATIC_DIR / path
-            if file_path.is_file() and ".." not in path:
+            # Check if a static file exists — with path traversal protection
+            file_path = (STATIC_DIR / path).resolve()
+            if (
+                file_path.is_file()
+                and ".." not in path
+                and str(file_path).startswith(str(_static_root))
+            ):
                 return FileResponse(str(file_path))
             # Otherwise serve index.html (SPA routing)
             return FileResponse(str(STATIC_DIR / "index.html"))

--- a/src/sovyx/dashboard/status.py
+++ b/src/sovyx/dashboard/status.py
@@ -119,10 +119,14 @@ class StatusCollector:
         """Collect a status snapshot from all services."""
         from sovyx import __version__
 
-        mind_name = await self._get_mind_name()
-        concepts, episodes = await self._get_memory_stats()
+        # Resolve mind once — used by both mind_name and memory stats
+        mind_id_str = await self._get_active_mind_id()
+        concepts, episodes = await self._get_memory_stats(mind_id_str)
 
         calls, cost, tokens, _msgs = get_counters().snapshot()
+
+        # Display "sovyx" for the default/fallback mind, real name otherwise
+        mind_name = "sovyx" if mind_id_str == "default" else mind_id_str
 
         return StatusSnapshot(
             version=__version__,
@@ -136,27 +140,13 @@ class StatusCollector:
             tokens_today=tokens,
         )
 
-    async def _get_mind_name(self) -> str:
-        """Get the active mind name."""
-        try:
-            from sovyx.engine.bootstrap import MindManager
-
-            if self._registry.is_registered(MindManager):
-                manager = await self._registry.resolve(MindManager)
-                minds = manager.get_active_minds()
-                if minds:
-                    return minds[0]
-        except Exception:  # noqa: BLE001
-            logger.debug("status_mind_name_failed")
-        return "sovyx"
-
-    async def _get_memory_stats(self) -> tuple[int, int]:
+    async def _get_memory_stats(self, mind_id_str: str) -> tuple[int, int]:
         """Get concept and episode counts from brain repositories."""
         from sovyx.engine.types import MindId
 
         concepts = 0
         episodes = 0
-        mind_id = MindId(await self._get_active_mind_id())
+        mind_id = MindId(mind_id_str)
 
         try:
             from sovyx.brain.concept_repo import ConceptRepository

--- a/tests/dashboard/test_adversarial.py
+++ b/tests/dashboard/test_adversarial.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import threading
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -287,6 +287,130 @@ class TestBrainGraphAdversarial:
 
 
 # ── Query Param Validation ──
+
+
+class TestBroadcastConcurrency:
+    """Verify broadcast doesn't hold lock during sends."""
+
+    @pytest.mark.asyncio()
+    async def test_broadcast_releases_lock_before_send(self) -> None:
+        """A slow client shouldn't block connect/disconnect."""
+        import asyncio
+
+        from sovyx.dashboard.server import ConnectionManager
+
+        mgr = ConnectionManager()
+
+        # Create mock websockets
+        fast_ws = MagicMock()
+        fast_ws.send_json = AsyncMock()
+        slow_ws = MagicMock()
+
+        async def slow_send(msg: object) -> None:
+            await asyncio.sleep(0.1)
+
+        slow_ws.send_json = AsyncMock(side_effect=slow_send)
+        slow_ws.accept = AsyncMock()
+        fast_ws.accept = AsyncMock()
+
+        await mgr.connect(slow_ws)
+        await mgr.connect(fast_ws)
+
+        # Start broadcast (will be slow due to slow_ws)
+        broadcast_task = asyncio.create_task(mgr.broadcast({"test": 1}))
+
+        # Meanwhile, a new connection should NOT be blocked
+        new_ws = MagicMock()
+        new_ws.accept = AsyncMock()
+        # Give broadcast a moment to start
+        await asyncio.sleep(0.01)
+        # This should complete without waiting for broadcast
+        connect_task = asyncio.create_task(mgr.connect(new_ws))
+        done, _pending = await asyncio.wait({connect_task}, timeout=0.05)
+        assert len(done) == 1, "connect() was blocked by broadcast()"
+
+        await broadcast_task
+        assert mgr.active_count == 3
+
+    @pytest.mark.asyncio()
+    async def test_broadcast_removes_stale_after_send(self) -> None:
+        """Stale connections removed after failed sends."""
+        from sovyx.dashboard.server import ConnectionManager
+
+        mgr = ConnectionManager()
+        good_ws = MagicMock()
+        good_ws.send_json = AsyncMock()
+        good_ws.accept = AsyncMock()
+        bad_ws = MagicMock()
+        bad_ws.send_json = AsyncMock(side_effect=ConnectionError("gone"))
+        bad_ws.accept = AsyncMock()
+
+        await mgr.connect(good_ws)
+        await mgr.connect(bad_ws)
+        assert mgr.active_count == 2
+
+        await mgr.broadcast({"test": 1})
+        assert mgr.active_count == 1
+        good_ws.send_json.assert_called_once()
+
+
+class TestBrainGraphLinksCap:
+    """Verify brain graph links are capped."""
+
+    @pytest.mark.asyncio()
+    async def test_links_respect_max_cap(self) -> None:
+        """Links returned should not exceed max_links."""
+        import aiosqlite
+
+        from sovyx.dashboard.brain import _get_relations
+
+        conn = await aiosqlite.connect(":memory:")
+        await conn.executescript(
+            "CREATE TABLE relations (id TEXT, source_id TEXT, target_id TEXT, "
+            "relation_type TEXT, weight REAL)"
+        )
+        # Insert 50 relations between 10 nodes
+        for i in range(50):
+            src = f"c{i % 10}"
+            tgt = f"c{(i + 1) % 10}"
+            await conn.execute(
+                "INSERT INTO relations VALUES (?, ?, ?, 'related', 0.5)",
+                (f"r{i}", src, tgt),
+            )
+        await conn.commit()
+
+        class _Pool:
+            class _Ctx:
+                def __init__(self, c: aiosqlite.Connection) -> None:
+                    self._c = c
+
+                async def __aenter__(self) -> aiosqlite.Connection:
+                    return self._c
+
+                async def __aexit__(self, *a: object) -> None:
+                    pass
+
+            def __init__(self, c: aiosqlite.Connection) -> None:
+                self._c = c
+
+            def read(self) -> _Pool._Ctx:
+                return self._Ctx(self._c)
+
+        pool = _Pool(conn)
+
+        db_manager = MagicMock()
+        db_manager.get_brain_pool.return_value = pool
+
+        registry = MagicMock()
+        registry.is_registered.return_value = True
+        registry.resolve = AsyncMock(return_value=db_manager)
+
+        node_ids = {f"c{i}" for i in range(10)}
+        links = await _get_relations(registry, node_ids, max_links=5)
+
+        assert len(links) <= 5
+
+        await conn.close()
 
 
 class TestQueryParamValidation:


### PR DESCRIPTION
## Security & Concurrency Audit (Round 4)

### Fixes
1. **Broadcast lock** 🔴: slow WS client blocked ALL others + connect/disconnect. Fixed: copy-then-release pattern
2. **SPA path traversal** 🟡: added `resolve().startswith(STATIC_DIR)` defense-in-depth
3. **Brain graph links cap** 🟡: unbounded links → capped at 3×node limit
4. **Mind resolve cache** 🟢: 2 MindManager lookups → 1 per status request

### 163 tests
`mypy --strict` ✅ | `ruff` ✅ | `bandit` ✅